### PR TITLE
Correct vertex attribute array position for descriptor

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1374,7 +1374,7 @@ namespace plume {
         for (uint32_t i = 0; i < desc.inputElementsCount; i++) {
             const RenderInputElement &inputElement = desc.inputElements[i];
 
-            MTL::VertexAttributeDescriptor *attributeDescriptor = vertexDescriptor->attributes()->object(i);
+            MTL::VertexAttributeDescriptor *attributeDescriptor = vertexDescriptor->attributes()->object(inputElement.location);
             attributeDescriptor->setOffset(inputElement.alignedByteOffset);
 
             const uint32_t vertexBufferIndex = std::min(PUSH_CONSTANT_MAX_INDEX + 1 + inputElement.slotIndex, VERTEX_BUFFER_MAX_INDEX);


### PR DESCRIPTION
The vulkan location of the input elements is translated into the attribute descriptor array in Metal.

Src (MoltenVK) -https://github.com/KhronosGroup/MoltenVK/blob/83510e0f3835c3c43651dda087305abc42572e17/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm#L1511