### PR TITLE
Metal: Remove needs update optimisation

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2212,7 +2212,7 @@ namespace plume {
                 vertexBufferIndices[i] = newIndex;
             }
 
-			this->viewCount = viewCount;
+            this->viewCount = viewCount;
             dirtyGraphicsState.vertexBuffers = 1;
         }
     }

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2196,13 +2196,6 @@ namespace plume {
         if ((views != nullptr) && (viewCount > 0)) {
             assert(inputSlots != nullptr);
 
-            bool needsUpdate = false;
-
-            // First time binding or different count requires full update
-            if (this->viewCount != viewCount) {
-                needsUpdate = true;
-            }
-
             // Resize our storage if needed
             vertexBuffers.resize(viewCount);
             vertexBufferOffsets.resize(viewCount);
@@ -2214,18 +2207,13 @@ namespace plume {
                 const uint64_t newOffset = views[i].buffer.offset;
                 const uint32_t newIndex = startSlot + i;
 
-                // Check if this binding differs from current state
-                needsUpdate = i >= stateCache.lastVertexBuffers.size() || interfaceBuffer->mtl != stateCache.lastVertexBuffers[i] || newOffset != stateCache.lastVertexBufferOffsets[i] || newIndex != stateCache.lastVertexBufferIndices[i];
-
                 vertexBuffers[i] = interfaceBuffer->mtl;
                 vertexBufferOffsets[i] = newOffset;
                 vertexBufferIndices[i] = newIndex;
             }
 
-            if (needsUpdate) {
-                this->viewCount = viewCount;
-                dirtyGraphicsState.vertexBuffers = 1;
-            }
+			this->viewCount = viewCount;
+            dirtyGraphicsState.vertexBuffers = 1;
         }
     }
 


### PR DESCRIPTION
Reasons for removal:
- It's not present on Vulkan or D3D12 backends
- It's not triggered by Unleashed or RT64 which already avoid duplicate vertex bindings
- It's fairly computationally expensive and may be more trouble than it's worth
- It's current implementation is incorrect, and causes vertex buffers to not be bound correctly in some cases