### PR TITLE
Vulkan: Support array texture types in texture view constructor

### DIFF
--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -278,16 +278,16 @@ namespace plume {
         }
     }
 
-    static VkImageViewType toImageViewType(RenderTextureViewDimension dimension) {
+    static VkImageViewType toImageViewType(RenderTextureViewDimension dimension, uint16_t arraySize) {
         switch (dimension) {
         case RenderTextureViewDimension::TEXTURE_1D:
-            return VK_IMAGE_VIEW_TYPE_1D;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_1D_ARRAY : VK_IMAGE_VIEW_TYPE_1D;
         case RenderTextureViewDimension::TEXTURE_2D:
-            return VK_IMAGE_VIEW_TYPE_2D;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
         case RenderTextureViewDimension::TEXTURE_3D:
             return VK_IMAGE_VIEW_TYPE_3D;
         case RenderTextureViewDimension::TEXTURE_CUBE:
-            return VK_IMAGE_VIEW_TYPE_CUBE;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY : VK_IMAGE_VIEW_TYPE_CUBE;
         default:
             assert(false && "Unknown resource dimension.");
             return VK_IMAGE_VIEW_TYPE_MAX_ENUM;
@@ -1035,7 +1035,7 @@ namespace plume {
         VkImageViewCreateInfo viewInfo = {};
         viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
         viewInfo.image = texture->vk;
-        viewInfo.viewType = toImageViewType(desc.dimension);
+        viewInfo.viewType = toImageViewType(desc.dimension, texture->desc.arraySize);
         viewInfo.format = toVk(desc.format);
         viewInfo.components.r = toVk(desc.componentMapping.r);
         viewInfo.components.g = toVk(desc.componentMapping.g);


### PR DESCRIPTION
This adds support for creating array views of an array, which previously caused created 2D Array textures to break. Necessary for MarathonRecomp, which uses a Texture2DArray for shadow maps.