### PR TITLE
Implement stencil test and combined depth-stencil format.

### DIFF
--- a/plume_d3d12.h
+++ b/plume_d3d12.h
@@ -177,6 +177,7 @@ namespace plume {
         const D3D12GraphicsPipeline *activeGraphicsPipeline = nullptr;
         bool descriptorHeapsSet = false;
         D3D12_PRIMITIVE_TOPOLOGY activeTopology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+        uint32_t activeStencilRef = 0;
         bool activeSamplePositions = false;
 
         D3D12CommandList(D3D12CommandQueue *queue);
@@ -206,7 +207,7 @@ namespace plume {
         void setFramebuffer(const RenderFramebuffer *framebuffer) override;
         void setDepthBias(float depthBias, float depthBiasClamp, float slopeScaledDepthBias) override;
         void clearColor(uint32_t attachmentIndex, RenderColor colorValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
-        void clearDepth(bool clearDepth, float depthValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
+        void clearDepthStencil(bool clearDepth, bool clearStencil, float depthValue, uint32_t stencilValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
         void copyBufferRegion(RenderBufferReference dstBuffer, RenderBufferReference srcBuffer, uint64_t size) override;
         void copyTextureRegion(const RenderTextureCopyLocation &dstLocation, const RenderTextureCopyLocation &srcLocation, uint32_t dstX, uint32_t dstY, uint32_t dstZ, const RenderBox *srcBox) override;
         void copyBuffer(const RenderBuffer *dstBuffer, const RenderBuffer *srcBuffer) override;
@@ -221,6 +222,7 @@ namespace plume {
         void checkDescriptorHeaps();
         void notifyDescriptorHeapWasChangedExternally();
         void checkTopology();
+        void checkStencilRef();
         void checkFramebufferSamplePositions();
         void setSamplePositions(const RenderTexture *texture);
         void resetSamplePositions();
@@ -393,6 +395,7 @@ namespace plume {
         ID3D12PipelineState *d3d = nullptr;
         std::vector<RenderInputSlot> inputSlots;
         D3D12_PRIMITIVE_TOPOLOGY topology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+        uint32_t stencilRef = 0;
 
         D3D12GraphicsPipeline(D3D12Device *device, const RenderGraphicsPipelineDesc &desc);
         ~D3D12GraphicsPipeline() override;

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -71,6 +71,7 @@ namespace plume {
             uint64_t value = 0;
             struct {
                 uint64_t depthClear: 1;
+                uint64_t stencilClear: 1;
                 uint64_t msaaCount: 4;
                 uint64_t colorFormat0: 7;
                 uint64_t colorFormat1: 7;
@@ -185,6 +186,7 @@ namespace plume {
         MTL::DepthClipMode depthClipMode = MTL::DepthClipModeClip;
         MTL::Winding winding = MTL::WindingClockwise;
         MTL::PrimitiveType primitiveType = MTL::PrimitiveTypeTriangle;
+        uint32_t stencilReference = 0;
         float depthBiasConstantFactor;
         float depthBiasClamp;
         float depthBiasSlopeFactor;
@@ -376,7 +378,7 @@ namespace plume {
         void setFramebuffer(const RenderFramebuffer *framebuffer) override;
         void setDepthBias(float depthBias, float depthBiasClamp, float slopeScaledDepthBias) override;
         void clearColor(uint32_t attachmentIndex, RenderColor colorValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
-        void clearDepth(bool clearDepth, float depthValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
+        void clearDepthStencil(bool clearDepth, bool clearStencil, float depthValue, uint32_t stencilValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
         void copyBufferRegion(RenderBufferReference dstBuffer, RenderBufferReference srcBuffer, uint64_t size) override;
         void copyTextureRegion(const RenderTextureCopyLocation &dstLocation, const RenderTextureCopyLocation &srcLocation, uint32_t dstX, uint32_t dstY, uint32_t dstZ, const RenderBox *srcBox) override;
         void copyBuffer(const RenderBuffer *dstBuffer, const RenderBuffer *srcBuffer) override;
@@ -580,6 +582,9 @@ namespace plume {
         MTL::Function* clearVertexFunction;
         MTL::Function* clearColorFunction;
         MTL::Function* clearDepthFunction;
+        MTL::Function* clearStencilFunction;
+        MTL::DepthStencilState *clearDepthState;
+        MTL::DepthStencilState *clearStencilState;
         MTL::DepthStencilState *clearDepthStencilState;
 
         std::mutex clearPipelineStateMutex;
@@ -621,7 +626,7 @@ namespace plume {
         void createResolvePipelineState();
         void createClearShaderLibrary();
 
-        MTL::RenderPipelineState* getOrCreateClearRenderPipelineState(MTL::RenderPipelineDescriptor *pipelineDesc, bool depthWriteEnabled = false);
+        MTL::RenderPipelineState* getOrCreateClearRenderPipelineState(MTL::RenderPipelineDescriptor *pipelineDesc, bool depthWriteEnabled = false, bool stencilWriteEnabled = false);
     };
 
     struct MetalInterface : RenderInterface {

--- a/plume_render_interface.h
+++ b/plume_render_interface.h
@@ -137,7 +137,7 @@ namespace plume {
         virtual void setFramebuffer(const RenderFramebuffer *framebuffer) = 0;
         virtual void setDepthBias(float depthBias, float depthBiasClamp, float slopeScaledDepthBias) = 0;
         virtual void clearColor(uint32_t attachmentIndex = 0, RenderColor colorValue = RenderColor(), const RenderRect *clearRects = nullptr, uint32_t clearRectsCount = 0) = 0;
-        virtual void clearDepth(bool clearDepth = true, float depthValue = 1.0f, const RenderRect *clearRects = nullptr, uint32_t clearRectsCount = 0) = 0;
+        virtual void clearDepthStencil(bool clearDepth = true, bool clearStencil = true, float depthValue = 1.0f, uint32_t stencilValue = 0, const RenderRect *clearRects = nullptr, uint32_t clearRectsCount = 0) = 0;
         virtual void copyBufferRegion(RenderBufferReference dstBuffer, RenderBufferReference srcBuffer, uint64_t size) = 0;
         virtual void copyTextureRegion(const RenderTextureCopyLocation &dstLocation, const RenderTextureCopyLocation &srcLocation, uint32_t dstX = 0, uint32_t dstY = 0, uint32_t dstZ = 0, const RenderBox *srcBox = nullptr) = 0;
         virtual void copyBuffer(const RenderBuffer *dstBuffer, const RenderBuffer *srcBuffer) = 0;
@@ -189,6 +189,10 @@ namespace plume {
 
         inline void setScissors(const RenderRect &scissorRect) {
             setScissors(&scissorRect, 1);
+        }
+
+        inline void clearDepth(bool clearDepth = true, float depthValue = 1.0f, const RenderRect *clearRects = nullptr, uint32_t clearRectsCount = 0) {
+            clearDepthStencil(clearDepth, false, depthValue, 0, clearRects, clearRectsCount);
         }
     };
 

--- a/plume_render_interface_types.h
+++ b/plume_render_interface_types.h
@@ -116,6 +116,7 @@ namespace plume {
         R16G16_SINT,
         R32_TYPELESS,
         D32_FLOAT,
+        D32_FLOAT_S8_UINT,
         R32_FLOAT,
         R32_UINT,
         R32_SINT,
@@ -225,6 +226,18 @@ namespace plume {
         NOT_EQUAL,
         GREATER_EQUAL,
         ALWAYS
+    };
+
+    enum class RenderStencilOp {
+        UNKNOWN,
+        KEEP,
+        ZERO,
+        REPLACE,
+        INCREMENT_AND_CLAMP,
+        DECREMENT_AND_CLAMP,
+        INVERT,
+        INCREMENT_AND_WRAP,
+        DECREMENT_AND_WRAP
     };
 
     enum class RenderInputSlotClassification {
@@ -525,6 +538,7 @@ namespace plume {
         case RenderFormat::R32G32_FLOAT:
         case RenderFormat::R32G32_UINT:
         case RenderFormat::R32G32_SINT:
+        case RenderFormat::D32_FLOAT_S8_UINT: // Has 24 unused bits
             return 8;
         case RenderFormat::R8G8B8A8_TYPELESS:
         case RenderFormat::R8G8B8A8_UNORM:
@@ -623,6 +637,7 @@ namespace plume {
         case RenderFormat::R16G16_SINT:
         case RenderFormat::R32_TYPELESS:
         case RenderFormat::D32_FLOAT:
+        case RenderFormat::D32_FLOAT_S8_UINT:
         case RenderFormat::R32_FLOAT:
         case RenderFormat::R32_UINT:
         case RenderFormat::R32_SINT:
@@ -671,6 +686,21 @@ namespace plume {
             return 1;
         }
     };
+
+    constexpr bool RenderFormatIsDepth(RenderFormat format) {
+        switch (format) {
+        case RenderFormat::D16_UNORM:
+        case RenderFormat::D32_FLOAT:
+        case RenderFormat::D32_FLOAT_S8_UINT:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    constexpr bool RenderFormatIsStencil(RenderFormat format) {
+        return format == RenderFormat::D32_FLOAT_S8_UINT;
+    }
 
     // Concrete structs.
 
@@ -1168,6 +1198,13 @@ namespace plume {
         }
     };
 
+    struct RenderStencilFaceDesc {
+        RenderStencilOp passOp = RenderStencilOp::KEEP;
+        RenderStencilOp failOp = RenderStencilOp::KEEP;
+        RenderStencilOp depthFailOp = RenderStencilOp::KEEP;
+        RenderComparisonFunction compareFunction = RenderComparisonFunction::ALWAYS;
+    };
+
     struct RenderSpecConstant {
         uint32_t index = 0;
         uint32_t value = 0;
@@ -1215,6 +1252,12 @@ namespace plume {
         bool dynamicDepthBiasEnabled = false;
         bool depthEnabled = false;
         bool depthWriteEnabled = false;
+        bool stencilEnabled = false;
+        uint32_t stencilReadMask = 0xFFFFFFFF;
+        uint32_t stencilWriteMask = 0xFFFFFFFF;
+        uint32_t stencilReference = 0;
+        RenderStencilFaceDesc stencilFrontFace;
+        RenderStencilFaceDesc stencilBackFace;
         RenderMultisampling multisampling;
         bool alphaToCoverageEnabled = false;
         RenderPrimitiveTopology primitiveTopology = RenderPrimitiveTopology::TRIANGLE_LIST;

--- a/plume_vulkan.h
+++ b/plume_vulkan.h
@@ -329,7 +329,7 @@ namespace plume {
         void setFramebuffer(const RenderFramebuffer *framebuffer) override;
         void setDepthBias(float depthBias, float depthBiasClamp, float slopeScaledDepthBias) override;
         void clearColor(uint32_t attachmentIndex, RenderColor colorValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
-        void clearDepth(bool clearDepth, float depthValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
+        void clearDepthStencil(bool clearDepth, bool clearStencil, float depthValue, uint32_t stencilValue, const RenderRect *clearRects, uint32_t clearRectsCount) override;
         void copyBufferRegion(RenderBufferReference dstBuffer, RenderBufferReference srcBuffer, uint64_t size) override;
         void copyTextureRegion(const RenderTextureCopyLocation &dstLocation, const RenderTextureCopyLocation &srcLocation, uint32_t dstX, uint32_t dstY, uint32_t dstZ, const RenderBox *srcBox) override;
         void copyBuffer(const RenderBuffer *dstBuffer, const RenderBuffer *srcBuffer) override;


### PR DESCRIPTION
* Add pipeline state for configuring stencil test.
* Add `D32_FLOAT_S8_UINT` combined depth-stencil format.
* Add logic where needed to handle combined depth-stencil formats for each API.
  * All three have updated depth clear so you can use `clearDepth` like before or `clearDepthStencil` to clear either/both of depth and stencil for a combined depth-stencil attachment.
  * Vulkan needed adjustments to image aspect flag bits to account for stencil.
  * D3D12 needed to use `DXGI_FORMAT_R32G8X24_TYPELESS` as base format and then specialize to `DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS` for texture view of depth and `DXGI_FORMAT_D32_FLOAT_S8X24_UINT` for actual depth-stencil attachment.
  * Metal needed to handle setting the stencil attachment format in pipeline descriptors as well when the depth-stencil attachment has a stencil component.

Vulkan and D3D12 were tested in [MarathonRecomp](https://github.com/ga2mer/MarathonRecomp), Metal I modifed the example from https://github.com/renderbag/plume/pull/18 to use depth and stencil for basic testing.