### PR TITLE
Array size

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -1106,18 +1106,40 @@ namespace plume {
                 const bool isMSAA = (interfaceTextureView->texture->desc.multisampling.sampleCount > RenderSampleCount::COUNT_1);
                 switch (interfaceTextureView->dimension) {
                 case RenderTextureViewDimension::TEXTURE_1D:
-                    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
-                    srvDesc.Texture1D.MipLevels = interfaceTextureView->mipLevels;
-                    srvDesc.Texture1D.MostDetailedMip = interfaceTextureView->mipSlice;
+                    if (interfaceTextureView->arraySize > 1) {
+                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
+                        srvDesc.Texture1DArray.MipLevels = interfaceTextureView->mipLevels;
+                        srvDesc.Texture1DArray.MostDetailedMip = interfaceTextureView->mipSlice;
+                        srvDesc.Texture1DArray.FirstArraySlice = interfaceTextureView->arrayIndex;
+                        srvDesc.Texture1DArray.ArraySize = interfaceTextureView->arraySize;
+                    } else {
+                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
+                        srvDesc.Texture1D.MipLevels = interfaceTextureView->mipLevels;
+                        srvDesc.Texture1D.MostDetailedMip = interfaceTextureView->mipSlice;
+                    }
                     break;
                 case RenderTextureViewDimension::TEXTURE_2D:
                     if (isMSAA) {
-                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
+                        if (interfaceTextureView->arraySize > 1) {
+                            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
+                            srvDesc.Texture2DMSArray.FirstArraySlice = interfaceTextureView->arrayIndex;
+                            srvDesc.Texture2DMSArray.ArraySize = interfaceTextureView->arraySize;
+                        } else {
+                            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
+                        }
                     }
                     else {
-                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-                        srvDesc.Texture2D.MipLevels = interfaceTextureView->mipLevels;
-                        srvDesc.Texture2D.MostDetailedMip = interfaceTextureView->mipSlice;
+                        if (interfaceTextureView->arraySize > 1) {
+                            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+                            srvDesc.Texture2DArray.MipLevels = interfaceTextureView->mipLevels;
+                            srvDesc.Texture2DArray.MostDetailedMip = interfaceTextureView->mipSlice;
+                            srvDesc.Texture2DArray.FirstArraySlice = interfaceTextureView->arrayIndex;
+                            srvDesc.Texture2DArray.ArraySize = interfaceTextureView->arraySize;
+                        } else {
+                            srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+                            srvDesc.Texture2D.MipLevels = interfaceTextureView->mipLevels;
+                            srvDesc.Texture2D.MostDetailedMip = interfaceTextureView->mipSlice;
+                        }
                     }
 
                     break;
@@ -1127,9 +1149,17 @@ namespace plume {
                     srvDesc.Texture3D.MostDetailedMip = interfaceTextureView->mipSlice;
                     break;
                 case RenderTextureViewDimension::TEXTURE_CUBE:
-                    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
-                    srvDesc.TextureCube.MipLevels = interfaceTextureView->mipLevels;
-                    srvDesc.TextureCube.MostDetailedMip = interfaceTextureView->mipSlice;
+                    if (interfaceTextureView->arraySize > 6) {
+                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
+                        srvDesc.TextureCubeArray.MipLevels = interfaceTextureView->mipLevels;
+                        srvDesc.TextureCubeArray.MostDetailedMip = interfaceTextureView->mipSlice;
+                        srvDesc.TextureCubeArray.First2DArrayFace = interfaceTextureView->arrayIndex;
+                        srvDesc.TextureCubeArray.NumCubes = interfaceTextureView->arraySize / 6;
+                    } else {
+                        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
+                        srvDesc.TextureCube.MipLevels = interfaceTextureView->mipLevels;
+                        srvDesc.TextureCube.MostDetailedMip = interfaceTextureView->mipSlice;
+                    }
                     break;
                 default:
                     assert(false && "Unknown texture dimension.");
@@ -1159,12 +1189,26 @@ namespace plume {
 
                 switch (interfaceTextureView->dimension) {
                 case RenderTextureViewDimension::TEXTURE_1D:
-                    uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
-                    uavDesc.Texture1D.MipSlice = interfaceTextureView->mipSlice;
+                    if (interfaceTextureView->arraySize > 1) {
+                        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+                        uavDesc.Texture1DArray.MipSlice = interfaceTextureView->mipSlice;
+                        uavDesc.Texture1DArray.FirstArraySlice = interfaceTextureView->arrayIndex;
+                        uavDesc.Texture1DArray.ArraySize = interfaceTextureView->arraySize;
+                    } else {
+                        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+                        uavDesc.Texture1D.MipSlice = interfaceTextureView->mipSlice;
+                    }
                     break;
                 case RenderTextureViewDimension::TEXTURE_2D:
-                    uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-                    uavDesc.Texture2D.MipSlice = interfaceTextureView->mipSlice;
+                    if (interfaceTextureView->arraySize > 1) {
+                        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+                        uavDesc.Texture2DArray.MipSlice = interfaceTextureView->mipSlice;
+                        uavDesc.Texture2DArray.FirstArraySlice = interfaceTextureView->arrayIndex;
+                        uavDesc.Texture2DArray.ArraySize = interfaceTextureView->arraySize;
+                    } else {
+                        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+                        uavDesc.Texture2D.MipSlice = interfaceTextureView->mipSlice;
+                    }
                     break;
                 case RenderTextureViewDimension::TEXTURE_3D:
                     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1227,11 +1227,14 @@ namespace plume {
     MetalTextureView::MetalTextureView(MetalTexture *texture, const RenderTextureViewDesc &desc) {
         assert(texture != nullptr);
 
+        const uint32_t mipLevels = std::min(desc.mipLevels, texture->desc.mipLevels - desc.mipSlice);
+        const uint32_t arraySize = std::min(desc.arraySize, texture->desc.arraySize - desc.arrayIndex);
+
         this->texture = texture->mtl->newTextureView(
             mapPixelFormat(desc.format),
-            mapTextureViewType(desc.dimension, texture->desc.multisampling.sampleCount, texture->desc.arraySize),
-            { desc.mipSlice, std::min(desc.mipLevels, texture->desc.mipLevels - desc.mipSlice) },
-            { desc.arrayIndex, std::min(desc.arraySize, texture->desc.arraySize - desc.arrayIndex) },
+            mapTextureViewType(desc.dimension, texture->desc.multisampling.sampleCount, arraySize),
+            { desc.mipSlice, mipLevels },
+            { desc.arrayIndex, arraySize },
             mapTextureSwizzleChannels(desc.componentMapping)
         );
     }

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -280,16 +280,16 @@ namespace plume {
         }
     }
 
-    static VkImageViewType toImageViewType(RenderTextureViewDimension dimension) {
+    static VkImageViewType toImageViewType(RenderTextureViewDimension dimension, uint16_t arraySize) {
         switch (dimension) {
         case RenderTextureViewDimension::TEXTURE_1D:
-            return VK_IMAGE_VIEW_TYPE_1D;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_1D_ARRAY : VK_IMAGE_VIEW_TYPE_1D;
         case RenderTextureViewDimension::TEXTURE_2D:
-            return VK_IMAGE_VIEW_TYPE_2D;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
         case RenderTextureViewDimension::TEXTURE_3D:
             return VK_IMAGE_VIEW_TYPE_3D;
         case RenderTextureViewDimension::TEXTURE_CUBE:
-            return VK_IMAGE_VIEW_TYPE_CUBE;
+            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY : VK_IMAGE_VIEW_TYPE_CUBE;
         default:
             assert(false && "Unknown resource dimension.");
             return VK_IMAGE_VIEW_TYPE_MAX_ENUM;
@@ -1073,7 +1073,7 @@ namespace plume {
         VkImageViewCreateInfo viewInfo = {};
         viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
         viewInfo.image = texture->vk;
-        viewInfo.viewType = toImageViewType(desc.dimension);
+        viewInfo.viewType = toImageViewType(desc.dimension, texture->desc.arraySize);
         viewInfo.format = toVk(desc.format);
         viewInfo.components.r = toVk(desc.componentMapping.r);
         viewInfo.components.g = toVk(desc.componentMapping.g);

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -1058,7 +1058,7 @@ namespace plume {
         imageSubresourceRange.baseMipLevel = 0;
         imageSubresourceRange.levelCount = desc.mipLevels;
         imageSubresourceRange.baseArrayLayer = 0;
-        imageSubresourceRange.layerCount = 1;
+        imageSubresourceRange.layerCount = desc.arraySize;
     }
 
     // VulkanTextureView
@@ -1070,10 +1070,13 @@ namespace plume {
 
         this->texture = texture;
 
+        const uint32_t mipLevels = std::min(desc.mipLevels, texture->desc.mipLevels - desc.mipSlice);
+        const uint32_t arraySize = std::min(desc.arraySize, texture->desc.arraySize - desc.arrayIndex);
+
         VkImageViewCreateInfo viewInfo = {};
         viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
         viewInfo.image = texture->vk;
-        viewInfo.viewType = toImageViewType(desc.dimension, texture->desc.arraySize);
+        viewInfo.viewType = toImageViewType(desc.dimension, arraySize);
         viewInfo.format = toVk(desc.format);
         viewInfo.components.r = toVk(desc.componentMapping.r);
         viewInfo.components.g = toVk(desc.componentMapping.g);
@@ -1081,9 +1084,9 @@ namespace plume {
         viewInfo.components.a = toVk(desc.componentMapping.a);
         viewInfo.subresourceRange.aspectMask = toViewAspectFlags(texture->desc.flags);
         viewInfo.subresourceRange.baseMipLevel = desc.mipSlice;
-        viewInfo.subresourceRange.levelCount = std::min(desc.mipLevels, texture->desc.mipLevels - desc.mipSlice);
+        viewInfo.subresourceRange.levelCount = mipLevels;
         viewInfo.subresourceRange.baseArrayLayer = desc.arrayIndex;
-        viewInfo.subresourceRange.layerCount = std::min(desc.arraySize, texture->desc.arraySize - desc.arrayIndex);
+        viewInfo.subresourceRange.layerCount = arraySize;
 
         VkResult res = vkCreateImageView(texture->device->vk, &viewInfo, nullptr, &vk);
         if (res != VK_SUCCESS) {

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -289,7 +289,7 @@ namespace plume {
         case RenderTextureViewDimension::TEXTURE_3D:
             return VK_IMAGE_VIEW_TYPE_3D;
         case RenderTextureViewDimension::TEXTURE_CUBE:
-            return arraySize > 1 ? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY : VK_IMAGE_VIEW_TYPE_CUBE;
+            return arraySize > 6 ? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY : VK_IMAGE_VIEW_TYPE_CUBE;
         default:
             assert(false && "Unknown resource dimension.");
             return VK_IMAGE_VIEW_TYPE_MAX_ENUM;


### PR DESCRIPTION
* Fix Metal oversight in https://github.com/renderbag/plume/pull/28 using the base texture array size instead of view array size.
* Build on https://github.com/renderbag/plume/pull/29 for Vulkan, fixing the same issue as above and setting array size of the VulkanTexture image view.
* Fix SRV/UAV creation with array views in D3D12.