### PR TITLE
Metal: Fix compiler return warning

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1758,6 +1758,7 @@ namespace plume {
 
     std::unique_ptr<RenderTextureView> MetalDrawable::createTextureView(const RenderTextureViewDesc& desc) {
         assert(false && "Drawables don't support texture views");
+        return nullptr;
     }
 
     void MetalDrawable::setName(const std::string &name) {


### PR DESCRIPTION
Very minor change, just adding a dummy return after an assert to stop compiler from warning about a non-void function with no return.