### PR TITLE
Improve object debug name support.

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -2535,7 +2535,7 @@ namespace plume {
         return std::make_unique<D3D12BufferFormattedView>(this, format);
     }
 
-    void D3D12Buffer::setName(const std::string &name) {
+    void D3D12Buffer::setName(const std::string &name) const {
         setObjectName(d3d, name);
     }
 
@@ -2636,7 +2636,7 @@ namespace plume {
         return std::make_unique<D3D12TextureView>(this, desc);
     }
 
-    void D3D12Texture::setName(const std::string &name) {
+    void D3D12Texture::setName(const std::string &name) const {
         setObjectName(d3d, name);
     }
 
@@ -2811,6 +2811,10 @@ namespace plume {
     }
 
     D3D12Shader::~D3D12Shader() { }
+
+    void D3D12Shader::setName(const std::string &name) const {
+        // Nothing to set a name on.
+    }
 
     // D3D12Sampler
 

--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -2535,7 +2535,7 @@ namespace plume {
         return std::make_unique<D3D12BufferFormattedView>(this, format);
     }
 
-    void D3D12Buffer::setName(const std::string &name) const {
+    void D3D12Buffer::setName(const std::string &name) {
         setObjectName(d3d, name);
     }
 
@@ -2636,7 +2636,7 @@ namespace plume {
         return std::make_unique<D3D12TextureView>(this, desc);
     }
 
-    void D3D12Texture::setName(const std::string &name) const {
+    void D3D12Texture::setName(const std::string &name) {
         setObjectName(d3d, name);
     }
 
@@ -2812,7 +2812,7 @@ namespace plume {
 
     D3D12Shader::~D3D12Shader() { }
 
-    void D3D12Shader::setName(const std::string &name) const {
+    void D3D12Shader::setName(const std::string &name) {
         // Nothing to set a name on.
     }
 
@@ -2896,7 +2896,7 @@ namespace plume {
         }
     }
 
-    void D3D12ComputePipeline::setName(const std::string& name) const {
+    void D3D12ComputePipeline::setName(const std::string &name) {
         setObjectName(d3d, name);
     }
 
@@ -3039,7 +3039,7 @@ namespace plume {
         }
     }
 
-    void D3D12GraphicsPipeline::setName(const std::string& name) const {
+    void D3D12GraphicsPipeline::setName(const std::string &name) {
         setObjectName(d3d, name);
     }
 
@@ -3263,7 +3263,7 @@ namespace plume {
         }
     }
 
-    void D3D12RaytracingPipeline::setName(const std::string& name) const {
+    void D3D12RaytracingPipeline::setName(const std::string &name) {
         setObjectName(stateObject, name);
     }
 

--- a/plume_d3d12.h
+++ b/plume_d3d12.h
@@ -277,7 +277,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -305,7 +305,7 @@ namespace plume {
         D3D12Texture(D3D12Device *device, D3D12Pool *pool, const RenderTextureDesc &desc);
         ~D3D12Texture() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         void createRenderTargetHeap();
         void createDepthStencilHeap();
         void releaseTargetHeap();
@@ -355,6 +355,7 @@ namespace plume {
 
         D3D12Shader(D3D12Device *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~D3D12Shader() override;
+        virtual void setName(const std::string &name) const override;
     };
 
     struct D3D12Sampler : RenderSampler {

--- a/plume_d3d12.h
+++ b/plume_d3d12.h
@@ -277,7 +277,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -305,7 +305,7 @@ namespace plume {
         D3D12Texture(D3D12Device *device, D3D12Pool *pool, const RenderTextureDesc &desc);
         ~D3D12Texture() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         void createRenderTargetHeap();
         void createDepthStencilHeap();
         void releaseTargetHeap();
@@ -355,7 +355,7 @@ namespace plume {
 
         D3D12Shader(D3D12Device *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~D3D12Shader() override;
-        virtual void setName(const std::string &name) const override;
+        virtual void setName(const std::string &name) override;
     };
 
     struct D3D12Sampler : RenderSampler {
@@ -388,7 +388,7 @@ namespace plume {
 
         D3D12ComputePipeline(D3D12Device *device, const RenderComputePipelineDesc &desc);
         ~D3D12ComputePipeline() override;
-        virtual void setName(const std::string& name) const override;
+        virtual void setName(const std::string &name) override;
         virtual RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 
@@ -400,7 +400,7 @@ namespace plume {
 
         D3D12GraphicsPipeline(D3D12Device *device, const RenderGraphicsPipelineDesc &desc);
         ~D3D12GraphicsPipeline() override;
-        virtual void setName(const std::string& name) const override;
+        virtual void setName(const std::string &name) override;
         virtual RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 
@@ -413,7 +413,7 @@ namespace plume {
 
         D3D12RaytracingPipeline(D3D12Device *device, const RenderRaytracingPipelineDesc &desc, const RenderPipeline *previousPipeline);
         ~D3D12RaytracingPipeline() override;
-        virtual void setName(const std::string& name) const override;
+        virtual void setName(const std::string &name) override;
         virtual RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1133,7 +1133,7 @@ namespace plume {
         return std::make_unique<MetalBufferFormattedView>(this, format);
     }
 
-    void MetalBuffer::setName(const std::string &name) const {
+    void MetalBuffer::setName(const std::string &name) {
         const NS::String *label = NS::String::string(name.c_str(), NS::UTF8StringEncoding);
         mtl->setLabel(label);
     }
@@ -1214,7 +1214,7 @@ namespace plume {
         return std::make_unique<MetalTextureView>(this, desc);
     }
 
-    void MetalTexture::setName(const std::string &name) const {
+    void MetalTexture::setName(const std::string &name) {
         mtl->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 
@@ -1301,7 +1301,7 @@ namespace plume {
         library->release();
     }
 
-    void MetalShader::setName(const std::string &name) const {
+    void MetalShader::setName(const std::string &name) {
         library->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 
@@ -1400,7 +1400,7 @@ namespace plume {
         if (state.pipelineState) state.pipelineState->release();
     }
 
-    void MetalComputePipeline::setName(const std::string& name) const {
+    void MetalComputePipeline::setName(const std::string &name) {
         // TODO: New - setting name happens at descriptor level - this would have to be reworked
     }
 
@@ -1554,7 +1554,7 @@ namespace plume {
         if (state.depthStencilState) state.depthStencilState->release();
     }
 
-    void MetalGraphicsPipeline::setName(const std::string& name) const {
+    void MetalGraphicsPipeline::setName(const std::string &name) {
         // TODO: New - setting name happens at descriptor level - this would have to be reworked
     }
 
@@ -1765,7 +1765,7 @@ namespace plume {
         return nullptr;
     }
 
-    void MetalDrawable::setName(const std::string &name) const {
+    void MetalDrawable::setName(const std::string &name) {
         mtl->texture()->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1133,7 +1133,7 @@ namespace plume {
         return std::make_unique<MetalBufferFormattedView>(this, format);
     }
 
-    void MetalBuffer::setName(const std::string &name) {
+    void MetalBuffer::setName(const std::string &name) const {
         const NS::String *label = NS::String::string(name.c_str(), NS::UTF8StringEncoding);
         mtl->setLabel(label);
     }
@@ -1214,7 +1214,7 @@ namespace plume {
         return std::make_unique<MetalTextureView>(this, desc);
     }
 
-    void MetalTexture::setName(const std::string &name) {
+    void MetalTexture::setName(const std::string &name) const {
         mtl->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 
@@ -1299,6 +1299,10 @@ namespace plume {
     MetalShader::~MetalShader() {
         functionName->release();
         library->release();
+    }
+
+    void MetalShader::setName(const std::string &name) const {
+        library->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 
     MTL::Function* MetalShader::createFunction(const RenderSpecConstant *specConstants, const uint32_t specConstantsCount) const {
@@ -1761,7 +1765,7 @@ namespace plume {
         return nullptr;
     }
 
-    void MetalDrawable::setName(const std::string &name) {
+    void MetalDrawable::setName(const std::string &name) const {
         mtl->texture()->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
     }
 

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -443,7 +443,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -463,7 +463,7 @@ namespace plume {
         MetalDrawable(MetalDevice *device, MetalPool *pool, const RenderTextureDesc &desc);
         ~MetalDrawable() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         MTL::Texture* getTexture() const override { return mtl->texture(); }
     };
 
@@ -477,7 +477,7 @@ namespace plume {
         MetalTexture(const MetalDevice *device, MetalPool *pool, const RenderTextureDesc &desc);
         ~MetalTexture() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         MTL::Texture* getTexture() const override { return mtl; }
     };
 
@@ -516,6 +516,7 @@ namespace plume {
 
         MetalShader(const MetalDevice *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~MetalShader() override;
+        virtual void setName(const std::string &name) const override;
         MTL::Function* createFunction(const RenderSpecConstant *specConstants, uint32_t specConstantsCount) const;
     };
 

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -443,7 +443,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -463,7 +463,7 @@ namespace plume {
         MetalDrawable(MetalDevice *device, MetalPool *pool, const RenderTextureDesc &desc);
         ~MetalDrawable() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         MTL::Texture* getTexture() const override { return mtl->texture(); }
     };
 
@@ -477,7 +477,7 @@ namespace plume {
         MetalTexture(const MetalDevice *device, MetalPool *pool, const RenderTextureDesc &desc);
         ~MetalTexture() override;
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         MTL::Texture* getTexture() const override { return mtl; }
     };
 
@@ -516,7 +516,7 @@ namespace plume {
 
         MetalShader(const MetalDevice *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~MetalShader() override;
-        virtual void setName(const std::string &name) const override;
+        virtual void setName(const std::string &name) override;
         MTL::Function* createFunction(const RenderSpecConstant *specConstants, uint32_t specConstantsCount) const;
     };
 
@@ -548,7 +548,7 @@ namespace plume {
         
         MetalComputePipeline(const MetalDevice *device, const RenderComputePipelineDesc &desc);
         ~MetalComputePipeline() override;
-        void setName(const std::string& name) const override;
+        void setName(const std::string &name) override;
         RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 
@@ -557,7 +557,7 @@ namespace plume {
         
         MetalGraphicsPipeline(const MetalDevice *device, const RenderGraphicsPipelineDesc &desc);
         ~MetalGraphicsPipeline() override;
-        void setName(const std::string& name) const override;
+        void setName(const std::string &name) override;
         RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 

--- a/plume_render_interface.h
+++ b/plume_render_interface.h
@@ -23,7 +23,7 @@ namespace plume {
         virtual void *map(uint32_t subresource = 0, const RenderRange *readRange = nullptr) = 0;
         virtual void unmap(uint32_t subresource = 0, const RenderRange *writtenRange = nullptr) = 0;
         virtual std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) = 0;
-        virtual void setName(const std::string &name) = 0;
+        virtual void setName(const std::string &name) const = 0;
         virtual uint64_t getDeviceAddress() const = 0;
 
         // Concrete implementation shortcuts.
@@ -39,7 +39,7 @@ namespace plume {
     struct RenderTexture {
         virtual ~RenderTexture() { }
         virtual std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) = 0;
-        virtual void setName(const std::string &name) = 0;
+        virtual void setName(const std::string &name) const = 0;
     };
 
     struct RenderAccelerationStructure {
@@ -48,6 +48,7 @@ namespace plume {
 
     struct RenderShader {
         virtual ~RenderShader() { }
+        virtual void setName(const std::string& name) const = 0;
     };
 
     struct RenderSampler {

--- a/plume_render_interface.h
+++ b/plume_render_interface.h
@@ -23,7 +23,7 @@ namespace plume {
         virtual void *map(uint32_t subresource = 0, const RenderRange *readRange = nullptr) = 0;
         virtual void unmap(uint32_t subresource = 0, const RenderRange *writtenRange = nullptr) = 0;
         virtual std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) = 0;
-        virtual void setName(const std::string &name) const = 0;
+        virtual void setName(const std::string &name) = 0;
         virtual uint64_t getDeviceAddress() const = 0;
 
         // Concrete implementation shortcuts.
@@ -39,7 +39,7 @@ namespace plume {
     struct RenderTexture {
         virtual ~RenderTexture() { }
         virtual std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) = 0;
-        virtual void setName(const std::string &name) const = 0;
+        virtual void setName(const std::string &name) = 0;
     };
 
     struct RenderAccelerationStructure {
@@ -48,7 +48,7 @@ namespace plume {
 
     struct RenderShader {
         virtual ~RenderShader() { }
-        virtual void setName(const std::string& name) const = 0;
+        virtual void setName(const std::string &name) = 0;
     };
 
     struct RenderSampler {
@@ -57,7 +57,7 @@ namespace plume {
 
     struct RenderPipeline {
         virtual ~RenderPipeline() { }
-        virtual void setName(const std::string& name) const = 0;
+        virtual void setName(const std::string &name) = 0;
         virtual RenderPipelineProgram getProgram(const std::string &name) const = 0;
     };
 

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -21,7 +21,7 @@
 
 #ifndef NDEBUG
 #   define VULKAN_VALIDATION_LAYER_ENABLED
-//#   define VULKAN_OBJECT_NAMES_ENABLED
+#   define VULKAN_OBJECT_NAMES_ENABLED
 #endif
 
 // TODO:
@@ -45,6 +45,9 @@ namespace plume {
 
     static const std::unordered_set<std::string> RequiredInstanceExtensions = {
         VK_KHR_SURFACE_EXTENSION_NAME,
+#   ifdef VULKAN_OBJECT_NAMES_ENABLED
+        VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+#   endif
 #   if defined(_WIN64)
         VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
 #   elif defined(__ANDROID__)
@@ -69,9 +72,6 @@ namespace plume {
         VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
         VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
         VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,
-#   ifdef VULKAN_OBJECT_NAMES_ENABLED
-        VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#   endif
     };
     
     static const std::unordered_set<std::string> OptionalDeviceExtensions = {
@@ -768,16 +768,16 @@ namespace plume {
         }
     }
 
-    static void setObjectName(VkDevice device, VkDebugReportObjectTypeEXT objectType, uint64_t object, const std::string &name) {
+    static void setObjectName(VkDevice device, VkObjectType objectType, uint64_t object, const std::string &name) {
 #   ifdef VULKAN_OBJECT_NAMES_ENABLED
-        VkDebugMarkerObjectNameInfoEXT nameInfo = {};
-        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
+        VkDebugUtilsObjectNameInfoEXT nameInfo = {};
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.objectType = objectType;
-        nameInfo.object = object;
+        nameInfo.objectHandle = object;
         nameInfo.pObjectName = name.c_str();
-        VkResult res = vkDebugMarkerSetObjectNameEXT(device, &nameInfo);
+        VkResult res = vkSetDebugUtilsObjectNameEXT(device, &nameInfo);
         if (res != VK_SUCCESS) {
-            fprintf(stderr, "vkDebugMarkerSetObjectNameEXT failed with error code 0x%X.\n", res);
+            fprintf(stderr, "vkSetDebugUtilsObjectNameEXT failed with error code 0x%X.\n", res);
             return;
         }
 #   endif
@@ -911,8 +911,8 @@ namespace plume {
         return std::make_unique<VulkanBufferFormattedView>(this, format);
     }
 
-    void VulkanBuffer::setName(const std::string &name) {
-        setObjectName(device->vk, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, uint64_t(vk), name);
+    void VulkanBuffer::setName(const std::string &name) const {
+        setObjectName(device->vk, VK_OBJECT_TYPE_IMAGE, uint64_t(vk), name);
     }
 
     uint64_t VulkanBuffer::getDeviceAddress() const {
@@ -1049,8 +1049,8 @@ namespace plume {
         return std::make_unique<VulkanTextureView>(this, desc);
     }
 
-    void VulkanTexture::setName(const std::string &name) {
-        setObjectName(device->vk, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, uint64_t(vk), name);
+    void VulkanTexture::setName(const std::string &name) const {
+        setObjectName(device->vk, VK_OBJECT_TYPE_IMAGE, uint64_t(vk), name);
     }
     
     void VulkanTexture::fillSubresourceRange() {
@@ -1299,6 +1299,10 @@ namespace plume {
         }
     }
 
+    void VulkanShader::setName(const std::string &name) const {
+        setObjectName(device->vk, VK_OBJECT_TYPE_SHADER_MODULE, uint64_t(vk), name);
+    }
+
     // VulkanSampler
 
     VulkanSampler::VulkanSampler(VulkanDevice *device, const RenderSamplerDesc &desc) {
@@ -1389,7 +1393,7 @@ namespace plume {
     }
 
     void VulkanComputePipeline::setName(const std::string& name) const {
-        setObjectName(device->vk, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, uint64_t(vk), name);
+        setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 
     RenderPipelineProgram VulkanComputePipeline::getProgram(const std::string &name) const {
@@ -1652,7 +1656,7 @@ namespace plume {
     }
 
     void VulkanGraphicsPipeline::setName(const std::string& name) const {
-        setObjectName(device->vk, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, uint64_t(vk), name);
+        setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 
     RenderPipelineProgram VulkanGraphicsPipeline::getProgram(const std::string &name) const {
@@ -1856,7 +1860,7 @@ namespace plume {
     }
 
     void VulkanRaytracingPipeline::setName(const std::string& name) const {
-        setObjectName(device->vk, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, uint64_t(vk), name);
+        setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 
     RenderPipelineProgram VulkanRaytracingPipeline::getProgram(const std::string &name) const {

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -911,7 +911,7 @@ namespace plume {
         return std::make_unique<VulkanBufferFormattedView>(this, format);
     }
 
-    void VulkanBuffer::setName(const std::string &name) const {
+    void VulkanBuffer::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_IMAGE, uint64_t(vk), name);
     }
 
@@ -1049,7 +1049,7 @@ namespace plume {
         return std::make_unique<VulkanTextureView>(this, desc);
     }
 
-    void VulkanTexture::setName(const std::string &name) const {
+    void VulkanTexture::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_IMAGE, uint64_t(vk), name);
     }
     
@@ -1299,7 +1299,7 @@ namespace plume {
         }
     }
 
-    void VulkanShader::setName(const std::string &name) const {
+    void VulkanShader::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_SHADER_MODULE, uint64_t(vk), name);
     }
 
@@ -1392,7 +1392,7 @@ namespace plume {
         }
     }
 
-    void VulkanComputePipeline::setName(const std::string& name) const {
+    void VulkanComputePipeline::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 
@@ -1655,7 +1655,7 @@ namespace plume {
         }
     }
 
-    void VulkanGraphicsPipeline::setName(const std::string& name) const {
+    void VulkanGraphicsPipeline::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 
@@ -1859,7 +1859,7 @@ namespace plume {
         }
     }
 
-    void VulkanRaytracingPipeline::setName(const std::string& name) const {
+    void VulkanRaytracingPipeline::setName(const std::string &name) {
         setObjectName(device->vk, VK_OBJECT_TYPE_PIPELINE, uint64_t(vk), name);
     }
 

--- a/plume_vulkan.h
+++ b/plume_vulkan.h
@@ -63,7 +63,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -95,7 +95,7 @@ namespace plume {
         ~VulkanTexture() override;
         void createImageView(VkFormat format);
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) override;
+        void setName(const std::string &name) const override;
         void fillSubresourceRange();
     };
 
@@ -145,6 +145,7 @@ namespace plume {
 
         VulkanShader(VulkanDevice *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~VulkanShader() override;
+        virtual void setName(const std::string &name) const override;
     };
 
     struct VulkanSampler : RenderSampler {

--- a/plume_vulkan.h
+++ b/plume_vulkan.h
@@ -63,7 +63,7 @@ namespace plume {
         void *map(uint32_t subresource, const RenderRange *readRange) override;
         void unmap(uint32_t subresource, const RenderRange *writtenRange) override;
         std::unique_ptr<RenderBufferFormattedView> createBufferFormattedView(RenderFormat format) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         uint64_t getDeviceAddress() const override;
     };
 
@@ -95,7 +95,7 @@ namespace plume {
         ~VulkanTexture() override;
         void createImageView(VkFormat format);
         std::unique_ptr<RenderTextureView> createTextureView(const RenderTextureViewDesc &desc) override;
-        void setName(const std::string &name) const override;
+        void setName(const std::string &name) override;
         void fillSubresourceRange();
     };
 
@@ -145,7 +145,7 @@ namespace plume {
 
         VulkanShader(VulkanDevice *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~VulkanShader() override;
-        virtual void setName(const std::string &name) const override;
+        virtual void setName(const std::string &name) override;
     };
 
     struct VulkanSampler : RenderSampler {
@@ -177,7 +177,7 @@ namespace plume {
 
         VulkanComputePipeline(VulkanDevice *device, const RenderComputePipelineDesc &desc);
         ~VulkanComputePipeline() override;
-        void setName(const std::string& name) const override;
+        void setName(const std::string &name) override;
         RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 
@@ -187,7 +187,7 @@ namespace plume {
 
         VulkanGraphicsPipeline(VulkanDevice *device, const RenderGraphicsPipelineDesc &desc);
         ~VulkanGraphicsPipeline() override;
-        void setName(const std::string& name) const override;
+        void setName(const std::string &name) override;
         RenderPipelineProgram getProgram(const std::string &name) const override;
         static VkRenderPass createRenderPass(VulkanDevice *device, const VkFormat *renderTargetFormat, uint32_t renderTargetCount, VkFormat depthTargetFormat, VkSampleCountFlagBits sampleCount);
     };
@@ -200,7 +200,7 @@ namespace plume {
 
         VulkanRaytracingPipeline(VulkanDevice *device, const RenderRaytracingPipelineDesc &desc, const RenderPipeline *previousPipeline);
         ~VulkanRaytracingPipeline() override;
-        void setName(const std::string& name) const override;
+        void setName(const std::string &name) override;
         RenderPipelineProgram getProgram(const std::string &name) const override;
     };
 


### PR DESCRIPTION
Some changes ported over that were made in MarathonRecomp:
* Add debug `setName` to shaders.
* Use `VK_EXT_debug_utils` properly.
  * Before it was added as a device extension, should be an instance extension.
  * Before the actual object name setting was using a function from `VK_EXT_debug_marker`, now is using the correct function from `VK_EXT_debug_utils`.

Plus:
* Fix consistency of `const` qualifier on `setName` functions.
* Uncomment enabling Vulkan object names for debug builds.