### PR TITLE
Metal: Set shader debug name on created MTLFunction.

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1295,10 +1295,17 @@ namespace plume {
     MetalShader::~MetalShader() {
         functionName->release();
         library->release();
+        if (debugName) {
+            debugName->release();
+        }
     }
 
     void MetalShader::setName(const std::string &name) {
-        library->setLabel(NS::String::string(name.c_str(), NS::UTF8StringEncoding));
+        if (debugName) {
+            debugName->release();
+        }
+        debugName = NS::String::string(name.c_str(), NS::UTF8StringEncoding);
+        library->setLabel(debugName);
     }
 
     MTL::Function* MetalShader::createFunction(const RenderSpecConstant *specConstants, const uint32_t specConstantsCount) const {
@@ -1316,6 +1323,10 @@ namespace plume {
         if (error != nullptr) {
             fprintf(stderr, "MTLLibrary newFunction: failed with error: %s.\n", error->localizedDescription()->utf8String());
             return nullptr;
+        }
+
+        if (debugName) {
+            function->setLabel(debugName);
         }
 
         return function;

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -528,6 +528,7 @@ namespace plume {
         NS::String *functionName = nullptr;
         RenderShaderFormat format = RenderShaderFormat::UNKNOWN;
         MTL::Library *library = nullptr;
+        NS::String *debugName = nullptr;
 
         MetalShader(const MetalDevice *device, const void *data, uint64_t size, const char *entryPointName, RenderShaderFormat format);
         ~MetalShader() override;


### PR DESCRIPTION
In the Metal debugger, the shaders only show the debug name if set on the `MTLFunction`. Handle this by storing the requested debug name and applying it to any created functions.