### PR TITLE
Metal: Residency sets and barriers

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -2764,6 +2764,7 @@ namespace plume {
     }
 
     uint64_t D3D12Buffer::getDeviceAddress() const {
+        assert((desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) != 0 && "Buffer must have been created with GPU_ADDRESSABLE flag.");
         return d3d->GetGPUVirtualAddress();
     }
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1103,9 +1103,33 @@ namespace plume {
         this->device = device;
 
         this->mtl = device->mtl->newBuffer(desc.size, mapResourceOption(desc.heapType));
+
+        if (desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) {
+            // If the buffer may be used by device address, we need to make sure it will be resident.
+            if (device->gpuAddressableResidencySet != nullptr) {
+                std::lock_guard lock(device->gpuAddressableResidencySetMutex);
+                device->gpuAddressableResidencySet->addAllocation(mtl);
+                device->gpuAddressableResidencySet->commit();
+            } else {
+                device->gpuAddressableResources.push_back(mtl);
+            }
+        }
     }
 
     MetalBuffer::~MetalBuffer() {
+        if (desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) {
+            if (device->gpuAddressableResidencySet != nullptr) {
+                std::lock_guard lock(device->gpuAddressableResidencySetMutex);
+                device->gpuAddressableResidencySet->removeAllocation(mtl);
+                device->gpuAddressableResidencySet->commit();
+            } else {
+                const auto it = std::find(device->gpuAddressableResources.begin(), device->gpuAddressableResources.end(), mtl);
+                if (it != device->gpuAddressableResources.end()) {
+                    device->gpuAddressableResources.erase(it);
+                }
+            }
+        }
+
         mtl->release();
     }
 
@@ -1134,6 +1158,7 @@ namespace plume {
 
     uint64_t MetalBuffer::getDeviceAddress() const {
         assert(device->mtl->supportsFamily(MTL::GPUFamilyMetal3) && "Device address is only supported on Metal3 devices.");
+        assert((desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) != 0 && "Buffer must have been created with GPU_ADDRESSABLE flag.");
         return mtl->gpuAddress();
     }
 
@@ -1610,6 +1635,15 @@ namespace plume {
 
         setLayout = std::make_unique<MetalDescriptorSetLayout>(device, desc);
 
+        if (device->supportsResidencySets()) {
+            MTL::ResidencySetDescriptor* descriptor = MTL::ResidencySetDescriptor::alloc()->init();
+            descriptor->setInitialCapacity(setLayout->descriptorBindingIndices.size());
+
+            residencySet = device->mtl->newResidencySet(descriptor, nullptr);
+
+            descriptor->release();
+        }
+
         uint64_t requiredSize = setLayout->argumentEncoder->encodedLength();
         requiredSize = alignUp(requiredSize, 256);
 
@@ -1626,8 +1660,9 @@ namespace plume {
     }
 
     MetalDescriptorSet::~MetalDescriptorSet() {
-        for (const auto resource: toReleaseOnDestruction) {
-            resource->release();
+        if (residencySet != nullptr) {
+            residencySet->endResidency();
+            residencySet->release();
         }
 
         for (const auto &entry : resourceEntries) {
@@ -1646,6 +1681,14 @@ namespace plume {
             for (uint32_t i = 0; i < binding.immutableSamplers.size(); i++) {
                 argumentBuffer.argumentEncoder->setSamplerState(binding.immutableSamplers[i], binding.binding + i);
             }
+        }
+    }
+
+    void MetalDescriptorSet::commit() {
+        if (needsCommit) {
+            std::lock_guard lock(residencySetWriteMutex);
+            residencySet->commit();
+            needsCommit = false;
         }
     }
 
@@ -1725,7 +1768,13 @@ namespace plume {
 
         if (dtype != MTL::DataTypeSampler) {
             if (resourceEntries[descriptorIndex].resource != nullptr) {
-                toReleaseOnDestruction.push_back(resourceEntries[descriptorIndex].resource);
+                if (residencySet != nullptr) {
+                    std::lock_guard lock(residencySetWriteMutex);
+                    residencySet->removeAllocation(resourceEntries[descriptorIndex].resource);
+                    needsCommit = true;
+                }
+                resourceEntries[descriptorIndex].resource->release();
+                resourceEntries[descriptorIndex].resource = nullptr;
             }
         }
 
@@ -1735,6 +1784,11 @@ namespace plume {
                     const TextureDescriptor *textureDescriptor = static_cast<const TextureDescriptor *>(descriptor);
                     nativeResource = textureDescriptor->texture;
                     MTL::Texture *nativeTexture = static_cast<MTL::Texture *>(nativeResource);
+                    if (residencySet != nullptr) {
+                        std::lock_guard lock(residencySetWriteMutex);
+                        residencySet->addAllocation(nativeTexture);
+                        needsCommit = true;
+                    }
                     argumentBuffer.argumentEncoder->setTexture(nativeTexture, descriptorIndex - indexBase + bindingIndex);
                     nativeTexture->retain();
                     break;
@@ -1743,6 +1797,11 @@ namespace plume {
                     const BufferDescriptor *bufferDescriptor = static_cast<const BufferDescriptor *>(descriptor);
                     nativeResource = bufferDescriptor->buffer;
                     MTL::Buffer *nativeBuffer = static_cast<MTL::Buffer *>(nativeResource);
+                    if (residencySet != nullptr) {
+                        std::lock_guard lock(residencySetWriteMutex);
+                        residencySet->addAllocation(nativeBuffer);
+                        needsCommit = true;
+                    }
                     argumentBuffer.argumentEncoder->setBuffer(nativeBuffer, bufferDescriptor->offset, descriptorIndex - indexBase + bindingIndex);
                     nativeBuffer->retain();
                     break;
@@ -2923,8 +2982,14 @@ namespace plume {
             dirtyComputeState.pipelineState = 0;
         }
 
+        for (auto* descriptorSet : computeDescriptorSets) {
+            if (descriptorSet) {
+                descriptorSet->commit();
+            }
+        }
+
         if (dirtyComputeState.descriptorSets) {
-            activeComputePipelineLayout->bindDescriptorSets(activeComputeEncoder, computeDescriptorSets, MAX_DESCRIPTOR_SET_BINDINGS, true, dirtyComputeState.descriptorSetDirtyIndex, currentEncoderDescriptorSets);
+            activeComputePipelineLayout->bindDescriptorSets(activeComputeEncoder, computeDescriptorSets, MAX_DESCRIPTOR_SET_BINDINGS, true, dirtyComputeState.descriptorSetDirtyIndex, currentEncoderDescriptorSets, mtl);
             dirtyComputeState.descriptorSets = 0;
             dirtyComputeState.descriptorSetDirtyIndex = MAX_DESCRIPTOR_SET_BINDINGS;
         }
@@ -3066,9 +3131,15 @@ namespace plume {
             dirtyGraphicsState.vertexBufferSlots = 0;
         }
 
+        for (auto* descriptorSet : renderDescriptorSets) {
+            if (descriptorSet) {
+                descriptorSet->commit();
+            }
+        }
+
         if (dirtyGraphicsState.descriptorSets) {
             if (activeGraphicsPipelineLayout) {
-                activeGraphicsPipelineLayout->bindDescriptorSets(activeRenderEncoder, renderDescriptorSets, MAX_DESCRIPTOR_SET_BINDINGS, false, dirtyGraphicsState.descriptorSetDirtyIndex, currentEncoderDescriptorSets);
+                activeGraphicsPipelineLayout->bindDescriptorSets(activeRenderEncoder, renderDescriptorSets, MAX_DESCRIPTOR_SET_BINDINGS, false, dirtyGraphicsState.descriptorSetDirtyIndex, currentEncoderDescriptorSets, mtl);
             }
             dirtyGraphicsState.descriptorSets = 0;
             dirtyGraphicsState.descriptorSetDirtyIndex = MAX_DESCRIPTOR_SET_BINDINGS + 1;
@@ -3150,8 +3221,17 @@ namespace plume {
     }
 
     void MetalCommandList::bindEncoderResources(MTL::CommandEncoder* encoder, bool isCompute) {
+        // If we support residency sets, they will be used
+        // and useResource should not be called
+        if (device->supportsResidencySets()) {
+            return;
+        }
+
         if (isCompute) {
             auto* computeEncoder = static_cast<MTL::ComputeCommandEncoder*>(encoder);
+            for (const auto* resource : device->gpuAddressableResources) {
+                computeEncoder->useResource(resource, MTL::ResourceUsageRead);
+            }
             for (const auto* descriptorSet : currentEncoderDescriptorSets) {
                 for (const auto& entry : descriptorSet->resourceEntries) {
                     if (entry.resource != nullptr) {
@@ -3161,6 +3241,9 @@ namespace plume {
             }
         } else {
             auto* renderEncoder = static_cast<MTL::RenderCommandEncoder*>(encoder);
+            for (const auto* resource : device->gpuAddressableResources) {
+                renderEncoder->useResource(resource, MTL::ResourceUsageRead);
+            }
             for (const auto* descriptorSet : currentEncoderDescriptorSets) {
                 for (const auto& entry : descriptorSet->resourceEntries) {
                     if (entry.resource != nullptr) {
@@ -3200,6 +3283,11 @@ namespace plume {
 
         this->device = device;
         this->mtl = device->mtl->newCommandQueue();
+
+        if (device->gpuAddressableResidencySet != nullptr) {
+            // Automatically add residency set for GPU-addressable buffers to all command buffers in the queue.
+            mtl->addResidencySet(device->gpuAddressableResidencySet);
+        }
     }
 
     MetalCommandQueue::~MetalCommandQueue() {
@@ -3279,7 +3367,7 @@ namespace plume {
 
     MetalPipelineLayout::~MetalPipelineLayout() {}
 
-    void MetalPipelineLayout::bindDescriptorSets(MTL::CommandEncoder* encoder, const MetalDescriptorSet* const* descriptorSets, uint32_t descriptorSetCount, bool isCompute, uint32_t startIndex, std::unordered_set<MetalDescriptorSet*>& encoderDescriptorSets) const {
+    void MetalPipelineLayout::bindDescriptorSets(MTL::CommandEncoder* encoder, const MetalDescriptorSet* const* descriptorSets, uint32_t descriptorSetCount, bool isCompute, uint32_t startIndex, std::unordered_set<MetalDescriptorSet*>& encoderDescriptorSets, MTL::CommandBuffer* commandBuffer) const {
         for (uint32_t i = startIndex; i < setLayoutCount; i++) {
             if (i >= descriptorSetCount || descriptorSets[i] == nullptr) {
                 continue;
@@ -3288,8 +3376,12 @@ namespace plume {
             const MetalDescriptorSet* descriptorSet = descriptorSets[i];
             const MetalArgumentBuffer& descriptorBuffer = descriptorSet->argumentBuffer;
 
-            // Track descriptor set for later resource binding
-            encoderDescriptorSets.insert(const_cast<MetalDescriptorSet*>(descriptorSet));
+            if (descriptorSet->residencySet != nullptr) {
+                commandBuffer->useResidencySet(descriptorSet->residencySet);
+            } else {
+                // Track descriptor set for later resource binding
+                encoderDescriptorSets.insert(const_cast<MetalDescriptorSet*>(descriptorSet));
+            }
 
             // Bind argument buffer
             if (isCompute) {
@@ -3354,6 +3446,12 @@ namespace plume {
         capabilities.queryPools = false;
 
         nullBuffer = createBuffer(RenderBufferDesc::DefaultBuffer(16, RenderBufferFlag::VERTEX));
+
+        if (supportsResidencySets()) {
+            MTL::ResidencySetDescriptor* residencySetDescriptor = MTL::ResidencySetDescriptor::alloc()->init();
+            gpuAddressableResidencySet = mtl->newResidencySet(residencySetDescriptor, nullptr);
+            residencySetDescriptor->release();
+        }
     }
 
     MetalDevice::~MetalDevice() {
@@ -3368,6 +3466,11 @@ namespace plume {
         clearColorFunction->release();
         clearDepthFunction->release();
         sharedBlitDescriptor->release();
+
+        if (gpuAddressableResidencySet != nullptr) {
+            gpuAddressableResidencySet->endResidency();
+            gpuAddressableResidencySet->release();
+        }
     }
 
     std::unique_ptr<RenderDescriptorSet> MetalDevice::createDescriptorSet(const RenderDescriptorSetDesc &desc) {
@@ -3484,6 +3587,16 @@ namespace plume {
         MTL::CaptureManager *manager = MTL::CaptureManager::sharedCaptureManager();
         manager->stopCapture();
         return true;
+    }
+
+    bool MetalDevice::supportsResidencySets() const {
+        // TODO: Enable once barriers are done.
+        /* NS::OperatingSystemVersion osVersion = NS::ProcessInfo::processInfo()->operatingSystemVersion();
+        if (osVersion.majorVersion >= 15) {
+            return mtl->supportsFamily(MTL::GPUFamilyApple6);
+        } */
+
+        return false;
     }
 
     void MetalDevice::createResolvePipelineState() {

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1106,8 +1106,8 @@ namespace plume {
 
         if (desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) {
             // If the buffer may be used by device address, we need to make sure it will be resident.
+            std::lock_guard lock(device->gpuAddressableResourcesMutex);
             if (device->gpuAddressableResidencySet != nullptr) {
-                std::lock_guard lock(device->gpuAddressableResidencySetMutex);
                 device->gpuAddressableResidencySet->addAllocation(mtl);
                 device->gpuAddressableResidencySet->commit();
             } else {
@@ -1118,8 +1118,8 @@ namespace plume {
 
     MetalBuffer::~MetalBuffer() {
         if (desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) {
+            std::lock_guard lock(device->gpuAddressableResourcesMutex);
             if (device->gpuAddressableResidencySet != nullptr) {
-                std::lock_guard lock(device->gpuAddressableResidencySetMutex);
                 device->gpuAddressableResidencySet->removeAllocation(mtl);
                 device->gpuAddressableResidencySet->commit();
             } else {
@@ -3390,6 +3390,7 @@ namespace plume {
         if (isCompute) {
             auto* computeEncoder = static_cast<MTL::ComputeCommandEncoder*>(encoder);
             if (device->gpuAddressableResidencySet == nullptr) {
+                std::lock_guard lock(device->gpuAddressableResourcesMutex);
                 for (const auto* resource : device->gpuAddressableResources) {
                     computeEncoder->useResource(resource, MTL::ResourceUsageRead);
                 }
@@ -3406,6 +3407,7 @@ namespace plume {
         } else {
             auto* renderEncoder = static_cast<MTL::RenderCommandEncoder*>(encoder);
             if (device->gpuAddressableResidencySet == nullptr) {
+                std::lock_guard lock(device->gpuAddressableResourcesMutex);
                 for (const auto* resource : device->gpuAddressableResources) {
                     renderEncoder->useResource(resource, MTL::ResourceUsageRead);
                 }

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2144,12 +2144,27 @@ namespace plume {
 
     MetalCommandList::~MetalCommandList() {
         mtl->release();
+
+        for (auto& fenceSet : fences) {
+            for (auto* fence : fenceSet) {
+                fence->release();
+            }
+        }
     }
 
     void MetalCommandList::begin() {
         assert(mtl == nullptr);
         mtl = queue->mtl->commandBufferWithUnretainedReferences();
         mtl->setLabel(MTLSTR("RT64 Command List"));
+
+        // Reset fence waits and updates for new command list.
+        fenceSlots.updateDirtyBits = ~0;
+        for (uint32_t dstStage = 0; dstStage < MetalBarrierStage::COUNT; dstStage++) {
+            for (uint32_t srcStage = 0; srcStage < MetalBarrierStage::COUNT; srcStage++) {
+                fenceSlots.wait[dstStage][srcStage] = -1;
+            }
+            fenceSlots.update[dstStage] = -1;
+        }
     }
 
     void MetalCommandList::end() {
@@ -2174,6 +2189,103 @@ namespace plume {
         mtl = nullptr;
     }
 
+    void MetalCommandList::barrierWait(MetalBarrierStage stage, MTL::RenderCommandEncoder* encoder) {
+        constexpr uint32_t beforeStages = MTL::RenderStageVertex | MTL::RenderStageFragment;
+        for (int i = 0; i < MetalBarrierStage::COUNT; ++i) {
+            int &fenceIndex = fenceSlots.wait[stage][i];
+            if (fenceIndex != -1) {
+                const MTL::Fence* fence = fences[i][fenceIndex];
+                encoder->waitForFence(fence, beforeStages);
+                fenceIndex = -1;
+            }
+        }
+    }
+
+    void MetalCommandList::barrierWait(MetalBarrierStage stage, MTL::ComputeCommandEncoder* encoder) {
+        for (int i = 0; i < MetalBarrierStage::COUNT; ++i) {
+            int &fenceIndex = fenceSlots.wait[stage][i];
+            if (fenceIndex != -1) {
+                const MTL::Fence* fence = fences[i][fenceIndex];
+                encoder->waitForFence(fence);
+                fenceIndex = -1;
+            }
+        }
+    }
+
+    void MetalCommandList::barrierWait(MetalBarrierStage stage, MTL::BlitCommandEncoder* encoder) {
+        for (int i = 0; i < MetalBarrierStage::COUNT; ++i) {
+            int &fenceIndex = fenceSlots.wait[stage][i];
+            if (fenceIndex != -1) {
+                const MTL::Fence* fence = fences[i][fenceIndex];
+                encoder->waitForFence(fence);
+                fenceIndex = -1;
+            }
+        }
+    }
+
+    void MetalCommandList::barrierUpdate(MetalBarrierStage stage, MTL::RenderCommandEncoder* encoder) {
+        constexpr uint32_t beforeStages = MTL::RenderStageVertex | MTL::RenderStageFragment;
+        const MTL::Fence* fence = getBarrierStageFence(stage);
+        if (fence != nullptr) {
+            encoder->updateFence(fence, beforeStages);
+        }
+    }
+
+    void MetalCommandList::barrierUpdate(MetalBarrierStage stage, MTL::ComputeCommandEncoder* encoder) {
+        const MTL::Fence* fence = getBarrierStageFence(stage);
+        if (fence != nullptr) {
+            encoder->updateFence(fence);
+        }
+    }
+
+    void MetalCommandList::barrierUpdate(MetalBarrierStage stage, MTL::BlitCommandEncoder* encoder) {
+        const MTL::Fence* fence = getBarrierStageFence(stage);
+        if (fence != nullptr) {
+            encoder->updateFence(fence);
+        }
+    }
+
+    MTL::Fence *MetalCommandList::getBarrierStageFence(MetalBarrierStage stage) {
+        const uint32_t dirtyMask = 1 << stage;
+        if ((fenceSlots.updateDirtyBits & dirtyMask) == dirtyMask) {
+            fenceSlots.updateDirtyBits &= ~dirtyMask;
+            ++fenceSlots.update[stage];
+
+            if (fenceSlots.update[stage] >= fences[stage].size()) {
+                MTL::Fence* fence = fences[stage].emplace_back(device->mtl->newFence());
+
+                char label[100];
+                snprintf(label, sizeof(label), "%s Fence %d", MetalBarrierStageName(stage).c_str(), fenceSlots.update[stage]);
+                fence->setLabel(NS::String::string(label, NS::UTF8StringEncoding));
+            }
+        }
+
+        if (fenceSlots.update[stage] < 0) {
+            return nullptr;
+        }
+
+        return fences[stage][fenceSlots.update[stage]];
+    }
+
+    void MetalCommandList::setBarrier(uint64_t sourceStageMask, uint64_t destStageMask) {
+        for (int i = 0; i < MetalBarrierStage::COUNT; ++i) {
+            if ((sourceStageMask & (1 << i)) == 0) {
+                continue;
+            }
+
+            for (int j = 0; j < MetalBarrierStage::COUNT; ++j) {
+                if ((destStageMask & (1 << j)) == 0) {
+                    continue;
+                }
+
+                fenceSlots.wait[j][i] = fenceSlots.update[i];
+            }
+
+            fenceSlots.wait[i][i] = fenceSlots.update[i];
+            fenceSlots.updateDirtyBits |= 1 << i;
+        }
+    }
+
     void MetalCommandList::barriers(RenderBarrierStages stages, const RenderBufferBarrier *bufferBarriers, const uint32_t bufferBarriersCount, const RenderTextureBarrier *textureBarriers, const uint32_t textureBarriersCount) {
         assert(bufferBarriersCount == 0 || bufferBarriers != nullptr);
         assert(textureBarriersCount == 0 || textureBarriers != nullptr);
@@ -2185,6 +2297,46 @@ namespace plume {
         // End render passes on all barriers
         endActiveRenderEncoder();
         handlePendingClears();
+
+        uint64_t srcStageMask = 0;
+
+        for (int i = 0; i < bufferBarriersCount; i++) {
+            const RenderBufferBarrier &bufferBarrier = bufferBarriers[i];
+            MetalBuffer *interfaceBuffer = static_cast<MetalBuffer *>(bufferBarrier.buffer);
+
+            srcStageMask |= toStageMask(interfaceBuffer->barrierStages);
+            interfaceBuffer->barrierStages = stages;
+        }
+
+        for (int i = 0; i < textureBarriersCount; i++) {
+            const RenderTextureBarrier &textureBarrier = textureBarriers[i];
+            MetalTexture *interfaceTexture = static_cast<MetalTexture *>(textureBarrier.texture);
+
+            srcStageMask |= toStageMask(interfaceTexture->barrierStages);
+            interfaceTexture->barrierStages = stages;
+            // Ignore layout transitions on Metal
+            // interfaceTexture->layout = textureBarrier.layout;
+        }
+
+        setBarrier(srcStageMask, toStageMask(stages));
+    }
+
+    static uint64_t toStageMask(RenderBarrierStages stages) {
+        uint64_t mask = 0;
+
+        if (stages & RenderBarrierStage::GRAPHICS) {
+            mask |= 1 << MetalBarrierStage::GRAPHICS;
+        }
+
+        if (stages & RenderBarrierStage::COMPUTE) {
+            mask |= 1 << MetalBarrierStage::COMPUTE;
+        }
+
+        if (stages & RenderBarrierStage::COPY) {
+            mask |= 1 << MetalBarrierStage::COPY;
+        }
+
+        return mask;
     }
 
     void MetalCommandList::dispatch(const uint32_t threadGroupCountX, const uint32_t threadGroupCountY, const uint32_t threadGroupCountZ) {
@@ -2974,6 +3126,8 @@ namespace plume {
             activeComputeEncoder->retain();
             releasePool->release();
 
+            barrierWait(MetalBarrierStage::COMPUTE, activeComputeEncoder);
+
             dirtyComputeState.setAll();
         }
 
@@ -3010,6 +3164,7 @@ namespace plume {
     void MetalCommandList::endActiveComputeEncoder() {
         if (activeComputeEncoder != nullptr) {
             bindEncoderResources(activeComputeEncoder, true);
+            barrierUpdate(MetalBarrierStage::COMPUTE, activeComputeEncoder);
             activeComputeEncoder->endEncoding();
             activeComputeEncoder->release();
             activeComputeEncoder = nullptr;
@@ -3067,6 +3222,8 @@ namespace plume {
 
             activeRenderEncoder = mtl->renderCommandEncoder(renderDescriptor);
             activeRenderEncoder->setLabel(MTLSTR("Graphics Render Encoder"));
+
+            barrierWait(MetalBarrierStage::GRAPHICS, activeRenderEncoder);
 
             activeRenderEncoder->retain();
             releasePool->release();
@@ -3165,6 +3322,7 @@ namespace plume {
     void MetalCommandList::endActiveRenderEncoder() {
         if (activeRenderEncoder != nullptr) {
             bindEncoderResources(activeRenderEncoder, false);
+            barrierUpdate(MetalBarrierStage::GRAPHICS, activeRenderEncoder);
             activeRenderEncoder->endEncoding();
             activeRenderEncoder->release();
             activeRenderEncoder = nullptr;
@@ -3188,11 +3346,14 @@ namespace plume {
         if (activeBlitEncoder == nullptr) {
             activeBlitEncoder = mtl->blitCommandEncoder(device->sharedBlitDescriptor);
             activeBlitEncoder->setLabel(MTLSTR("Copy Blit Encoder"));
+
+            barrierWait(MetalBarrierStage::COPY, activeBlitEncoder);
         }
     }
 
     void MetalCommandList::endActiveBlitEncoder() {
         if (activeBlitEncoder != nullptr) {
+            barrierUpdate(MetalBarrierStage::COPY, activeBlitEncoder);
             activeBlitEncoder->endEncoding();
             activeBlitEncoder->release();
             activeBlitEncoder = nullptr;
@@ -3209,11 +3370,14 @@ namespace plume {
             activeResolveComputeEncoder = mtl->computeCommandEncoder();
             activeResolveComputeEncoder->setLabel(MTLSTR("Resolve Texture Encoder"));
             activeResolveComputeEncoder->setComputePipelineState(device->resolveTexturePipelineState);
+
+            barrierWait(MetalBarrierStage::COPY, activeResolveComputeEncoder);
         }
     }
 
     void MetalCommandList::endActiveResolveTextureComputeEncoder() {
         if (activeResolveComputeEncoder != nullptr) {
+            barrierUpdate(MetalBarrierStage::COPY, activeResolveComputeEncoder);
             activeResolveComputeEncoder->endEncoding();
             activeResolveComputeEncoder->release();
             activeResolveComputeEncoder = nullptr;
@@ -3590,11 +3754,10 @@ namespace plume {
     }
 
     bool MetalDevice::supportsResidencySets() const {
-        // TODO: Enable once barriers are done.
-        /* NS::OperatingSystemVersion osVersion = NS::ProcessInfo::processInfo()->operatingSystemVersion();
+        NS::OperatingSystemVersion osVersion = NS::ProcessInfo::processInfo()->operatingSystemVersion();
         if (osVersion.majorVersion >= 15) {
             return mtl->supportsFamily(MTL::GPUFamilyApple6);
-        } */
+        }
 
         return false;
     }
@@ -3742,7 +3905,6 @@ namespace plume {
         auto [inserted_it, success] = clearRenderPipelineStates.insert(std::make_pair(pipelineKey, clearPipelineState));
         return inserted_it->second;
     }
-
 
     // MetalInterface
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1637,7 +1637,7 @@ namespace plume {
 
         const uint32_t maxResources = setLayout->descriptorBindingIndices.size();
         // When using more than 128 resources, use residency sets for greater efficiency.
-        if (maxResources > 128 && device->supportsResidencySets()) {
+        if (maxResources > 128 && device->supportsResidencySets) {
             MTL::ResidencySetDescriptor* descriptor = MTL::ResidencySetDescriptor::alloc()->init();
             descriptor->setInitialCapacity(maxResources);
 
@@ -3592,6 +3592,8 @@ namespace plume {
         createResolvePipelineState();
         sharedBlitDescriptor = MTL::BlitPassDescriptor::alloc()->init();
 
+        NS::OperatingSystemVersion osVersion = NS::ProcessInfo::processInfo()->operatingSystemVersion();
+
         // Fill capabilities.
         // https://developer.apple.com/documentation/metal/device-inspection
         // TODO: Support Raytracing.
@@ -3599,13 +3601,7 @@ namespace plume {
         capabilities.maxTextureSize = mtl->supportsFamily(MTL::GPUFamilyApple3) ? 16384 : 8192;
         capabilities.sampleLocations = mtl->programmableSamplePositionsSupported();
         capabilities.resolveModes = false;
-#if PLUME_IOS
-        capabilities.descriptorIndexing = mtl->supportsFamily(MTL::GPUFamilyApple3);
-#else
-        capabilities.descriptorIndexing = true;
-#endif
         capabilities.scalarBlockLayout = true;
-        capabilities.bufferDeviceAddress = mtl->supportsFamily(MTL::GPUFamilyApple3);
         capabilities.presentWait = false;
         capabilities.preferHDR = mtl->recommendedMaxWorkingSetSize() > (512 * 1024 * 1024);
         capabilities.dynamicDepthBias = true;
@@ -3613,9 +3609,19 @@ namespace plume {
         capabilities.gpuUploadHeap = capabilities.uma;
         capabilities.queryPools = false;
 
+#if PLUME_IOS
+        capabilities.descriptorIndexing = mtl->supportsFamily(MTL::GPUFamilyApple3);
+        capabilities.bufferDeviceAddress = osVersion.majorVersion >= 16 && mtl->supportsFamily(MTL::GPUFamilyApple3);
+        supportsResidencySets = osVersion.majorVersion >= 18 && mtl->supportsFamily(MTL::GPUFamilyApple6);
+#else
+        capabilities.descriptorIndexing = true;
+        capabilities.bufferDeviceAddress = osVersion.majorVersion >= 13 && mtl->supportsFamily(MTL::GPUFamilyApple3);
+        supportsResidencySets = osVersion.majorVersion >= 15 && mtl->supportsFamily(MTL::GPUFamilyApple6);
+#endif
+
         nullBuffer = createBuffer(RenderBufferDesc::DefaultBuffer(16, RenderBufferFlag::VERTEX));
 
-        if (supportsResidencySets()) {
+        if (supportsResidencySets) {
             MTL::ResidencySetDescriptor* residencySetDescriptor = MTL::ResidencySetDescriptor::alloc()->init();
             gpuAddressableResidencySet = mtl->newResidencySet(residencySetDescriptor, nullptr);
             residencySetDescriptor->release();
@@ -3755,15 +3761,6 @@ namespace plume {
         MTL::CaptureManager *manager = MTL::CaptureManager::sharedCaptureManager();
         manager->stopCapture();
         return true;
-    }
-
-    bool MetalDevice::supportsResidencySets() const {
-        NS::OperatingSystemVersion osVersion = NS::ProcessInfo::processInfo()->operatingSystemVersion();
-        if (osVersion.majorVersion >= 15) {
-            return mtl->supportsFamily(MTL::GPUFamilyApple6);
-        }
-
-        return false;
     }
 
     void MetalDevice::createResolvePipelineState() {

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1635,9 +1635,11 @@ namespace plume {
 
         setLayout = std::make_unique<MetalDescriptorSetLayout>(device, desc);
 
-        if (device->supportsResidencySets()) {
+        const uint32_t maxResources = setLayout->descriptorBindingIndices.size();
+        // When using more than 128 resources, use residency sets for greater efficiency.
+        if (maxResources > 128 && device->supportsResidencySets()) {
             MTL::ResidencySetDescriptor* descriptor = MTL::ResidencySetDescriptor::alloc()->init();
-            descriptor->setInitialCapacity(setLayout->descriptorBindingIndices.size());
+            descriptor->setInitialCapacity(maxResources);
 
             residencySet = device->mtl->newResidencySet(descriptor, nullptr);
 
@@ -1656,7 +1658,7 @@ namespace plume {
         argumentBuffer.argumentEncoder->setArgumentBuffer(argumentBuffer.mtl, argumentBuffer.offset);
         bindImmutableSamplers();
 
-        resourceEntries.resize(setLayout->descriptorBindingIndices.size());
+        resourceEntries.resize(maxResources);
     }
 
     MetalDescriptorSet::~MetalDescriptorSet() {
@@ -3385,33 +3387,35 @@ namespace plume {
     }
 
     void MetalCommandList::bindEncoderResources(MTL::CommandEncoder* encoder, bool isCompute) {
-        // If we support residency sets, they will be used
-        // and useResource should not be called
-        if (device->supportsResidencySets()) {
-            return;
-        }
-
         if (isCompute) {
             auto* computeEncoder = static_cast<MTL::ComputeCommandEncoder*>(encoder);
-            for (const auto* resource : device->gpuAddressableResources) {
-                computeEncoder->useResource(resource, MTL::ResourceUsageRead);
+            if (device->gpuAddressableResidencySet == nullptr) {
+                for (const auto* resource : device->gpuAddressableResources) {
+                    computeEncoder->useResource(resource, MTL::ResourceUsageRead);
+                }
             }
             for (const auto* descriptorSet : currentEncoderDescriptorSets) {
-                for (const auto& entry : descriptorSet->resourceEntries) {
-                    if (entry.resource != nullptr) {
-                        computeEncoder->useResource(entry.resource, mapResourceUsage(entry.type));
+                if (descriptorSet->residencySet == nullptr) {
+                    for (const auto& entry : descriptorSet->resourceEntries) {
+                        if (entry.resource != nullptr) {
+                            computeEncoder->useResource(entry.resource, mapResourceUsage(entry.type));
+                        }
                     }
                 }
             }
         } else {
             auto* renderEncoder = static_cast<MTL::RenderCommandEncoder*>(encoder);
-            for (const auto* resource : device->gpuAddressableResources) {
-                renderEncoder->useResource(resource, MTL::ResourceUsageRead);
+            if (device->gpuAddressableResidencySet == nullptr) {
+                for (const auto* resource : device->gpuAddressableResources) {
+                    renderEncoder->useResource(resource, MTL::ResourceUsageRead);
+                }
             }
             for (const auto* descriptorSet : currentEncoderDescriptorSets) {
-                for (const auto& entry : descriptorSet->resourceEntries) {
-                    if (entry.resource != nullptr) {
-                        renderEncoder->useResource(entry.resource, mapResourceUsage(entry.type), MTL::RenderStageVertex | MTL::RenderStageFragment);
+                if (descriptorSet->residencySet == nullptr) {
+                    for (const auto& entry : descriptorSet->resourceEntries) {
+                        if (entry.resource != nullptr) {
+                            renderEncoder->useResource(entry.resource, mapResourceUsage(entry.type), MTL::RenderStageVertex | MTL::RenderStageFragment);
+                        }
                     }
                 }
             }

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -677,7 +677,7 @@ namespace plume {
 
         // GPU-addressable resources
         std::vector<MTL::Resource*> gpuAddressableResources;
-        MTL::ResidencySet* gpuAddressableResidencySet;
+        MTL::ResidencySet* gpuAddressableResidencySet = nullptr;
         std::mutex gpuAddressableResourcesMutex;
 
         explicit MetalDevice(MetalInterface *renderInterface, const std::string &preferredDeviceName);

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -300,6 +300,27 @@ namespace plume {
         virtual uint32_t getCount() const override;
     };
 
+    enum MetalBarrierStage {
+        GRAPHICS = 0,
+        COMPUTE,
+        COPY,
+        COUNT
+    };
+
+    static std::string MetalBarrierStageName(MetalBarrierStage stage) {
+        switch (stage) {
+            case MetalBarrierStage::GRAPHICS:
+                return "Graphics";
+            case MetalBarrierStage::COMPUTE:
+                return "Compute";
+            case MetalBarrierStage::COPY:
+                return "Copy";
+            default:
+                assert(false);
+                return "Unknown";
+        }
+    }
+
     struct MetalCommandList : RenderCommandList {
         union ClearValue {
             RenderColor color;
@@ -362,6 +383,13 @@ namespace plume {
             float depthBiasClamp;
             float slopeScaledDepthBias;
         } dynamicDepthBias;
+
+        struct {
+            uint32_t updateDirtyBits = ~0;
+            int update[MetalBarrierStage::COUNT] = {};
+            int wait[MetalBarrierStage::COUNT][MetalBarrierStage::COUNT] = {};
+        } fenceSlots;
+        std::vector<MTL::Fence*> fences[MetalBarrierStage::COUNT] = {};
 
         MetalDevice *device = nullptr;
         const MetalCommandQueue *queue = nullptr;
@@ -433,7 +461,20 @@ namespace plume {
         void checkForUpdatesInGraphicsState();
         void setCommonClearState() const;
         void handlePendingClears();
+
+        void barrierWait(MetalBarrierStage stage, MTL::RenderCommandEncoder* encoder);
+        void barrierWait(MetalBarrierStage stage, MTL::ComputeCommandEncoder* encoder);
+        void barrierWait(MetalBarrierStage stage, MTL::BlitCommandEncoder* encoder);
+
+        void barrierUpdate(MetalBarrierStage stage, MTL::RenderCommandEncoder* encoder);
+        void barrierUpdate(MetalBarrierStage stage, MTL::ComputeCommandEncoder* encoder);
+        void barrierUpdate(MetalBarrierStage stage, MTL::BlitCommandEncoder* encoder);
+
+        MTL::Fence* getBarrierStageFence(MetalBarrierStage stage);
+        void setBarrier(uint64_t sourceStageMask, uint64_t destStageMask);
     };
+
+    static uint64_t toStageMask(RenderBarrierStages stages);
 
     struct MetalCommandFence : RenderCommandFence {
         dispatch_semaphore_t semaphore;
@@ -467,6 +508,7 @@ namespace plume {
         MetalPool *pool = nullptr;
         MetalDevice *device = nullptr;
         RenderBufferDesc desc;
+        RenderBarrierStages barrierStages = RenderBarrierStage::NONE;
 
         MetalBuffer() = default;
         MetalBuffer(MetalDevice *device, MetalPool *pool, const RenderBufferDesc &desc);
@@ -503,6 +545,7 @@ namespace plume {
         RenderTextureLayout layout = RenderTextureLayout::UNKNOWN;
         MetalPool *pool = nullptr;
         MTL::Drawable *drawable = nullptr;
+        RenderBarrierStages barrierStages = RenderBarrierStage::NONE;
 
         MetalTexture() = default;
         MetalTexture(const MetalDevice *device, MetalPool *pool, const RenderTextureDesc &desc);
@@ -628,6 +671,7 @@ namespace plume {
         // Blit functionality
         MTL::BlitPassDescriptor *sharedBlitDescriptor = nullptr;
 
+        // Placeholder null buffer
         std::unique_ptr<RenderBuffer> nullBuffer;
 
         // GPU-addressable resources

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -678,7 +678,7 @@ namespace plume {
         // GPU-addressable resources
         std::vector<MTL::Resource*> gpuAddressableResources;
         MTL::ResidencySet* gpuAddressableResidencySet;
-        std::mutex gpuAddressableResidencySetMutex;
+        std::mutex gpuAddressableResourcesMutex;
 
         explicit MetalDevice(MetalInterface *renderInterface, const std::string &preferredDeviceName);
         ~MetalDevice() override;

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -213,7 +213,9 @@ namespace plume {
         std::vector<Descriptor> descriptors;
         MetalArgumentBuffer argumentBuffer;
         std::vector<ResourceEntry> resourceEntries;
-        std::vector<MTL::Resource *> toReleaseOnDestruction;
+        MTL::ResidencySet* residencySet = nullptr;
+        std::mutex residencySetWriteMutex;
+        bool needsCommit = false;
 
         MetalDescriptorSet(MetalDevice *device, const RenderDescriptorSetDesc &desc);
         MetalDescriptorSet(MetalDevice *device, uint32_t entryCount);
@@ -224,6 +226,7 @@ namespace plume {
         void setAccelerationStructure(uint32_t descriptorIndex, const RenderAccelerationStructure *accelerationStructure) override;
         void setDescriptor(uint32_t descriptorIndex, const Descriptor *descriptor);
         void bindImmutableSamplers() const;
+        void commit();
         RenderDescriptorRangeType getDescriptorType(uint32_t binding) const;
     };
 
@@ -367,8 +370,8 @@ namespace plume {
         const MetalPipelineLayout *activeGraphicsPipelineLayout = nullptr;
         const MetalRenderState *activeRenderState = nullptr;
         const MetalComputeState *activeComputeState = nullptr;
-        const MetalDescriptorSet* renderDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
-        const MetalDescriptorSet* computeDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
+        MetalDescriptorSet* renderDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
+        MetalDescriptorSet* computeDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
 
         std::unordered_set<MetalDescriptorSet*> currentEncoderDescriptorSets;
         void bindEncoderResources(MTL::CommandEncoder* encoder, bool isCompute);
@@ -598,7 +601,7 @@ namespace plume {
 
         MetalPipelineLayout(MetalDevice *device, const RenderPipelineLayoutDesc &desc);
         ~MetalPipelineLayout() override;
-        void bindDescriptorSets(MTL::CommandEncoder* encoder, const MetalDescriptorSet* const* descriptorSets, uint32_t descriptorSetCount, bool isCompute, uint32_t startIndex, std::unordered_set<MetalDescriptorSet*>& encoderDescriptorSets) const;
+        void bindDescriptorSets(MTL::CommandEncoder* encoder, const MetalDescriptorSet* const* descriptorSets, uint32_t descriptorSetCount, bool isCompute, uint32_t startIndex, std::unordered_set<MetalDescriptorSet*>& encoderDescriptorSets, MTL::CommandBuffer* commandBuffer) const;
     };
 
     struct MetalDevice : RenderDevice {
@@ -626,6 +629,11 @@ namespace plume {
         MTL::BlitPassDescriptor *sharedBlitDescriptor = nullptr;
 
         std::unique_ptr<RenderBuffer> nullBuffer;
+
+        // GPU-addressable resources
+        std::vector<MTL::Resource*> gpuAddressableResources;
+        MTL::ResidencySet* gpuAddressableResidencySet;
+        std::mutex gpuAddressableResidencySetMutex;
 
         explicit MetalDevice(MetalInterface *renderInterface, const std::string &preferredDeviceName);
         ~MetalDevice() override;
@@ -655,6 +663,7 @@ namespace plume {
         bool isValid() const;
         bool beginCapture() override;
         bool endCapture() override;
+        bool supportsResidencySets() const;
 
         // Shader libraries and pipeline states used for emulated operations
         void createResolvePipelineState();

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -652,6 +652,7 @@ namespace plume {
         MetalInterface *renderInterface = nullptr;
         RenderDeviceCapabilities capabilities;
         RenderDeviceDescription description;
+        bool supportsResidencySets;
 
         // Resolve functionality
         MTL::ComputePipelineState *resolveTexturePipelineState;
@@ -707,7 +708,6 @@ namespace plume {
         bool isValid() const;
         bool beginCapture() override;
         bool endCapture() override;
-        bool supportsResidencySets() const;
 
         // Shader libraries and pipeline states used for emulated operations
         void createResolvePipelineState();

--- a/plume_render_interface_types.h
+++ b/plume_render_interface_types.h
@@ -431,7 +431,8 @@ namespace plume {
             ACCELERATION_STRUCTURE_INPUT = 1U << 6,
             ACCELERATION_STRUCTURE_SCRATCH = 1U << 7,
             SHADER_BINDING_TABLE = 1U << 8,
-            UNORDERED_ACCESS = 1U << 9
+            UNORDERED_ACCESS = 1U << 9,
+            DEVICE_ADDRESSABLE = 1U << 10
         };
     };
 

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -908,6 +908,7 @@ namespace plume {
     }
 
     uint64_t VulkanBuffer::getDeviceAddress() const {
+        assert((desc.flags & RenderBufferFlag::DEVICE_ADDRESSABLE) != 0 && "Buffer must have been created with GPU_ADDRESSABLE flag.");
         VkBufferDeviceAddressInfo info;
         info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
         info.pNext = nullptr;


### PR DESCRIPTION
Based on https://github.com/renderbag/plume/pull/25, plus:
* Rebased on the latest changes.
* Residency sets:
  * Fixed location of `useResidencySet` and `commit` calls on residency set.
  * Added locking on residency set write and commit since residency sets are not thread-safe according to documentation and validation.
  * Fixed residency issues with GPU-addressable buffers.
* Barriers:
  * Moved fences to be per-command list and allocated as needed without a cap.
  * Reduced unneeded encoded fence waits/updates.
  * Fixed some bugs/typos.

I've tested this with UnleashedRecomp and MarathonRecomp and seem to be working okay with my changes added.

EDIT: Fixes #10 (not directly but makes it not necessary).