### PR TITLE
Metal: Implement query pools

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2132,15 +2132,23 @@ namespace plume {
 
         this->device = device;
 
-        // TODO: Unimplemented
-        // Dummy values, to be replaced with actual query results
+        MTL::CounterSampleBufferDescriptor *sampleBufferDesc = MTL::CounterSampleBufferDescriptor::alloc()->init();
+        sampleBufferDesc->setCounterSet(device->timestampCounterSet);
+        sampleBufferDesc->setStorageMode(MTL::StorageModeShared);
+        sampleBufferDesc->setSampleCount(queryCount);
+        sampleBuffer = device->mtl->newCounterSampleBuffer(sampleBufferDesc, nullptr);
+        sampleBufferDesc->release();
+
         results.resize(queryCount, 0);
     }
 
-    MetalQueryPool::~MetalQueryPool() { }
+    MetalQueryPool::~MetalQueryPool() {
+        sampleBuffer->release();
+    }
 
     void MetalQueryPool::queryResults() {
-        // TODO: Unimplemented
+        const NS::Data* data = sampleBuffer->resolveCounterRange(NS::Range(0, results.size()));
+        std::memcpy(results.data(), data->mutableBytes(), results.size() * sizeof(uint64_t));
     }
 
     const uint64_t *MetalQueryPool::getResults() const {
@@ -2156,6 +2164,9 @@ namespace plume {
     MetalCommandList::MetalCommandList(const MetalCommandQueue *queue) {
         this->device = queue->device;
         this->queue = queue;
+
+        timestampQueryFence = device->mtl->newFence();
+        timestampQueryFence->setLabel(MTLSTR("Timestamp Query Fence"));
     }
 
     MetalCommandList::~MetalCommandList() {
@@ -2166,6 +2177,8 @@ namespace plume {
                 fence->release();
             }
         }
+
+        timestampQueryFence->release();
     }
 
     void MetalCommandList::begin() {
@@ -3091,12 +3104,48 @@ namespace plume {
 
     void MetalCommandList::resetQueryPool(const RenderQueryPool *queryPool, uint32_t queryFirstIndex, uint32_t queryCount) {
         assert(queryPool != nullptr);
-        // TODO: Unimplemented
+        // No-op
     }
 
     void MetalCommandList::writeTimestamp(const RenderQueryPool *queryPool, uint32_t queryIndex) {
         assert(queryPool != nullptr);
-        // TODO: Unimplemented
+
+        const MetalQueryPool *interfaceQueryPool = static_cast<const MetalQueryPool *>(queryPool);
+
+        MTL::ComputeCommandEncoder *computeEncoder = activeComputeEncoder != nullptr ? activeComputeEncoder : activeResolveComputeEncoder;
+        if (computeEncoder != nullptr && device->mtl->supportsCounterSampling(MTL::CounterSamplingPointAtDispatchBoundary)) {
+            computeEncoder->sampleCountersInBuffer(interfaceQueryPool->sampleBuffer, queryIndex, true);
+        } else if (activeRenderEncoder != nullptr && device->mtl->supportsCounterSampling(MTL::CounterSamplingPointAtDrawBoundary)) {
+            activeRenderEncoder->sampleCountersInBuffer(interfaceQueryPool->sampleBuffer, queryIndex, true);
+        } else if (device->mtl->supportsCounterSampling(MTL::CounterSamplingPointAtBlitBoundary)) {
+            // If we are here because dispatch/draw sampling is not supported, end the
+            // current encoder and ensure we have a blit encoder for sampling.
+            endOtherEncoders(EncoderType::Blit);
+            checkActiveBlitEncoder();
+
+            activeBlitEncoder->sampleCountersInBuffer(interfaceQueryPool->sampleBuffer, queryIndex, true);
+        } else if (device->mtl->supportsCounterSampling(MTL::CounterSamplingPointAtStageBoundary)) {
+            // If the device does not support the required sampling point, but supports sampling at stage boundaries
+            // (e.g. Apple GPUs), we need to use a dummy blit encoder configured to sample to the buffer.
+            endOtherEncoders(EncoderType::None);
+
+            MTL::BlitPassDescriptor *descriptor = MTL::BlitPassDescriptor::alloc()->init();
+            MTL::BlitPassSampleBufferAttachmentDescriptor *sampleDescriptor = descriptor->sampleBufferAttachments()->object(0);
+            sampleDescriptor->setSampleBuffer(interfaceQueryPool->sampleBuffer);
+            sampleDescriptor->setStartOfEncoderSampleIndex(queryIndex);
+            sampleDescriptor->setEndOfEncoderSampleIndex(queryIndex);
+
+            MTL::BlitCommandEncoder *encoder = mtl->blitCommandEncoder(descriptor);
+            encoder->setLabel(MTLSTR("Timestamp Query Encoder"));
+            descriptor->release();
+
+            // Wait for query fence and perform dummy operation to record timestamp.
+            const MetalBuffer* nullBuffer = static_cast<const MetalBuffer *>(device->nullBuffer.get());
+            encoder->waitForFence(timestampQueryFence);
+            encoder->fillBuffer(nullBuffer->mtl, NS::Range(0, 1), 0);
+            encoder->endEncoding();
+            encoder->release();
+        }
     }
 
     void MetalCommandList::endOtherEncoders(EncoderType type) {
@@ -3179,6 +3228,7 @@ namespace plume {
         if (activeComputeEncoder != nullptr) {
             bindEncoderResources(activeComputeEncoder, true);
             barrierUpdate(MetalBarrierStage::COMPUTE, activeComputeEncoder);
+            activeComputeEncoder->updateFence(timestampQueryFence);
             activeComputeEncoder->endEncoding();
             activeComputeEncoder->release();
             activeComputeEncoder = nullptr;
@@ -3337,6 +3387,7 @@ namespace plume {
         if (activeRenderEncoder != nullptr) {
             bindEncoderResources(activeRenderEncoder, false);
             barrierUpdate(MetalBarrierStage::GRAPHICS, activeRenderEncoder);
+            activeRenderEncoder->updateFence(timestampQueryFence, MTL::RenderStageVertex | MTL::RenderStageFragment);
             activeRenderEncoder->endEncoding();
             activeRenderEncoder->release();
             activeRenderEncoder = nullptr;
@@ -3368,6 +3419,7 @@ namespace plume {
     void MetalCommandList::endActiveBlitEncoder() {
         if (activeBlitEncoder != nullptr) {
             barrierUpdate(MetalBarrierStage::COPY, activeBlitEncoder);
+            activeBlitEncoder->updateFence(timestampQueryFence);
             activeBlitEncoder->endEncoding();
             activeBlitEncoder->release();
             activeBlitEncoder = nullptr;
@@ -3392,6 +3444,7 @@ namespace plume {
     void MetalCommandList::endActiveResolveTextureComputeEncoder() {
         if (activeResolveComputeEncoder != nullptr) {
             barrierUpdate(MetalBarrierStage::COPY, activeResolveComputeEncoder);
+            activeResolveComputeEncoder->updateFence(timestampQueryFence);
             activeResolveComputeEncoder->endEncoding();
             activeResolveComputeEncoder->release();
             activeResolveComputeEncoder = nullptr;
@@ -3600,6 +3653,8 @@ namespace plume {
         description.vendor = mtl->supportsFamily(MTL::GPUFamilyApple1) ? RenderDeviceVendor::APPLE : getRenderDeviceVendor(mtl->registryID());
         description.dedicatedVideoMemory = mtl->recommendedMaxWorkingSetSize();
 
+        timestampCounterSet = findTimestampCounterSet();
+
         // Setup blit, clear and resolve shaders / pipelines
         createClearShaderLibrary();
         createResolvePipelineState();
@@ -3620,7 +3675,7 @@ namespace plume {
         capabilities.dynamicDepthBias = true;
         capabilities.uma = mtl->hasUnifiedMemory();
         capabilities.gpuUploadHeap = capabilities.uma;
-        capabilities.queryPools = false;
+        capabilities.queryPools = timestampCounterSet != nullptr;
         capabilities.samplerMirrorClampToEdge = true;
 
 #if PLUME_IOS
@@ -3777,6 +3832,18 @@ namespace plume {
         MTL::CaptureManager *manager = MTL::CaptureManager::sharedCaptureManager();
         manager->stopCapture();
         return true;
+    }
+
+    const MTL::CounterSet* MetalDevice::findTimestampCounterSet() const {
+        for (uint32_t setIndex = 0; setIndex < mtl->counterSets()->count(); setIndex++){
+            const MTL::CounterSet *counterSet = static_cast<MTL::CounterSet*>(mtl->counterSets()->object(setIndex));
+            for (uint32_t counterIndex = 0; counterIndex < counterSet->counters()->count(); counterIndex++) {
+                const MTL::Counter *counter = static_cast<MTL::Counter*>(counterSet->counters()->object(counterIndex));
+                if (counter->name()->isEqualToString(MTL::CommonCounterTimestamp))
+                    return counterSet;
+            }
+        }
+        return nullptr;
     }
 
     void MetalDevice::createResolvePipelineState() {

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2008,6 +2008,10 @@ namespace plume {
         drawable.desc.height = height;
         drawable.desc.flags = RenderTextureFlag::RENDER_TARGET;
         drawable.desc.format = mapRenderFormat(nextDrawable->texture()->pixelFormat());
+        if (drawable.mtl) {
+            // Release our reference before replacing.
+            drawable.mtl->release();
+        }
         drawable.mtl = nextDrawable;
 
         drawable.mtl->retain();
@@ -2147,8 +2151,12 @@ namespace plume {
     }
 
     void MetalQueryPool::queryResults() {
+        NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
+
         const NS::Data* data = sampleBuffer->resolveCounterRange(NS::Range(0, results.size()));
         std::memcpy(results.data(), data->mutableBytes(), results.size() * sizeof(uint64_t));
+
+        releasePool->release();
     }
 
     const uint64_t *MetalQueryPool::getResults() const {
@@ -2165,8 +2173,12 @@ namespace plume {
         this->device = queue->device;
         this->queue = queue;
 
+        NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
+
         timestampQueryFence = device->mtl->newFence();
         timestampQueryFence->setLabel(MTLSTR("Timestamp Query Fence"));
+
+        releasePool->release();
     }
 
     MetalCommandList::~MetalCommandList() {
@@ -3130,6 +3142,8 @@ namespace plume {
             // (e.g. Apple GPUs), we need to use a dummy blit encoder configured to sample to the buffer.
             endOtherEncoders(EncoderType::None);
 
+            NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
+
             MTL::BlitPassDescriptor *descriptor = MTL::BlitPassDescriptor::alloc()->init();
             MTL::BlitPassSampleBufferAttachmentDescriptor *sampleDescriptor = descriptor->sampleBufferAttachments()->object(0);
             sampleDescriptor->setSampleBuffer(interfaceQueryPool->sampleBuffer);
@@ -3147,7 +3161,8 @@ namespace plume {
             }
             encoder->fillBuffer(nullBuffer->mtl, NS::Range(0, 1), 0);
             encoder->endEncoding();
-            encoder->release();
+
+            releasePool->release();
         }
     }
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2183,6 +2183,7 @@ namespace plume {
 
     void MetalCommandList::begin() {
         assert(mtl == nullptr);
+        startedEncoding = false;
         mtl = queue->mtl->commandBufferWithUnretainedReferences();
         mtl->setLabel(MTLSTR("RT64 Command List"));
 
@@ -3141,7 +3142,9 @@ namespace plume {
 
             // Wait for query fence and perform dummy operation to record timestamp.
             const MetalBuffer* nullBuffer = static_cast<const MetalBuffer *>(device->nullBuffer.get());
-            encoder->waitForFence(timestampQueryFence);
+            if (startedEncoding) {
+                encoder->waitForFence(timestampQueryFence);
+            }
             encoder->fillBuffer(nullBuffer->mtl, NS::Range(0, 1), 0);
             encoder->endEncoding();
             encoder->release();
@@ -3188,6 +3191,8 @@ namespace plume {
 
             activeComputeEncoder->retain();
             releasePool->release();
+
+            startedEncoding = true;
 
             barrierWait(MetalBarrierStage::COMPUTE, activeComputeEncoder);
 
@@ -3291,6 +3296,8 @@ namespace plume {
 
             activeRenderEncoder->retain();
             releasePool->release();
+
+            startedEncoding = true;
             
             // Reset pending clears since we've now handled them
             if (pendingClears.active) {
@@ -3412,6 +3419,8 @@ namespace plume {
             activeBlitEncoder = mtl->blitCommandEncoder(device->sharedBlitDescriptor);
             activeBlitEncoder->setLabel(MTLSTR("Copy Blit Encoder"));
 
+            startedEncoding = true;
+
             barrierWait(MetalBarrierStage::COPY, activeBlitEncoder);
         }
     }
@@ -3436,6 +3445,8 @@ namespace plume {
             activeResolveComputeEncoder = mtl->computeCommandEncoder(MTL::DispatchTypeConcurrent);
             activeResolveComputeEncoder->setLabel(MTLSTR("Resolve Texture Encoder"));
             activeResolveComputeEncoder->setComputePipelineState(device->resolveTexturePipelineState);
+
+            startedEncoding = true;
 
             barrierWait(MetalBarrierStage::COPY, activeResolveComputeEncoder);
         }

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -298,6 +298,8 @@ namespace plume {
 
     struct MetalQueryPool : RenderQueryPool {
         MetalDevice *device = nullptr;
+        MTL::CounterSampleBuffer *sampleBuffer = nullptr;
+        uint32_t queryIndex = 0;
         std::vector<uint64_t> results;
 
         MetalQueryPool(MetalDevice *device, uint32_t queryCount);
@@ -407,6 +409,8 @@ namespace plume {
         const MetalComputeState *activeComputeState = nullptr;
         MetalDescriptorSet* renderDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
         MetalDescriptorSet* computeDescriptorSets[MAX_DESCRIPTOR_SET_BINDINGS] = {};
+
+        MTL::Fence *timestampQueryFence = nullptr;
 
         std::unordered_set<MetalDescriptorSet*> currentEncoderDescriptorSets;
         void bindEncoderResources(MTL::CommandEncoder* encoder, bool isCompute);
@@ -687,6 +691,9 @@ namespace plume {
         MTL::ResidencySet* gpuAddressableResidencySet = nullptr;
         std::mutex gpuAddressableResourcesMutex;
 
+        // Counter sets for query pools
+        const MTL::CounterSet* timestampCounterSet = nullptr;
+
         explicit MetalDevice(MetalInterface *renderInterface, const std::string &preferredDeviceName);
         ~MetalDevice() override;
         std::unique_ptr<RenderDescriptorSet> createDescriptorSet(const RenderDescriptorSetDesc &desc) override;
@@ -715,6 +722,8 @@ namespace plume {
         bool isValid() const;
         bool beginCapture() override;
         bool endCapture() override;
+
+        const MTL::CounterSet* findTimestampCounterSet() const;
 
         // Shader libraries and pipeline states used for emulated operations
         void createResolvePipelineState();

--- a/plume_metal.h
+++ b/plume_metal.h
@@ -299,7 +299,6 @@ namespace plume {
     struct MetalQueryPool : RenderQueryPool {
         MetalDevice *device = nullptr;
         MTL::CounterSampleBuffer *sampleBuffer = nullptr;
-        uint32_t queryIndex = 0;
         std::vector<uint64_t> results;
 
         MetalQueryPool(MetalDevice *device, uint32_t queryCount);
@@ -354,6 +353,7 @@ namespace plume {
 
         MTL::CommandBuffer *mtl = nullptr;
         EncoderType activeType = EncoderType::None;
+        bool startedEncoding = false;
         MTL::RenderCommandEncoder *activeRenderEncoder = nullptr;
         MTL::ComputeCommandEncoder *activeComputeEncoder = nullptr;
         MTL::BlitCommandEncoder *activeBlitEncoder = nullptr;


### PR DESCRIPTION
Implements timestamp query pools for Metal using counter sample buffers.
* If an encoder is active and the required sampling point is supported for sampling in the current encoder, just encode a `sampleCountersInBuffer` in the active encoder.
* If an encoder is not active, or sampling the current encoder is not supported, and blit sampling is supported, use a new blit encoder to encode a `sampleCountersInBuffer`.
* In all other cases, end the current active encoder and use a temporary blit encoder to wait for a fence and perform stage-boundary sampling.

I've checked this with UnleashedRecomp and both the dependency graph and timestamps look similar to what I get from MoltenVK on an Apple GPU.

EDIT: Fixes #8.