### PR TITLE
fix(metal): set initial layer size

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1868,7 +1868,9 @@ namespace plume {
         getWindowSize(width, height);
 
         // Set the layer's drawable size to match the window size
-        layer->setDrawableSize(CGSizeMake(width, height));
+        if (width > 0 && height > 0) {
+            layer->setDrawableSize(CGSizeMake(width, height));
+        }
 
         // set each of the drawable to have desc.flags = RenderTextureFlag::RENDER_TARGET;
         for (uint32_t i = 0; i < MAX_DRAWABLES; i++) {


### PR DESCRIPTION
Fixes an issue where on start the layer has the wrong size and therefore the drawables have the wrong size