### PR TITLE
Metal: Fix incorrect vertex step rate.

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1481,7 +1481,7 @@ namespace plume {
             } else {
                 layout->setStride(inputSlot.stride);
                 layout->setStepFunction(mapVertexStepFunction(inputSlot.classification));
-                layout->setStepRate((layout->stepFunction() == MTL::VertexStepFunctionPerInstance) ? inputSlot.stride : 1);
+                layout->setStepRate(1);
             }
         }
 


### PR DESCRIPTION
Vertex step rate should be 1, not the attribute stride.