### PR TITLE
Vulkan: Mark command list as one-time submit.

### DIFF
--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -2769,6 +2769,7 @@ namespace plume {
 
         VkCommandBufferBeginInfo beginInfo = {};
         beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
         VkResult res = vkBeginCommandBuffer(vk, &beginInfo);
         if (res != VK_SUCCESS) {


### PR DESCRIPTION
Implements https://github.com/renderbag/plume/issues/27.

Signal to Vulkan that the command list will be submitted only once, since that's the assumption made for plume.