### PR TITLE
Add support for specifying front face.

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -3092,6 +3092,8 @@ namespace plume {
             return;
         }
 
+        psoDesc.RasterizerState.FrontCounterClockwise = desc.frontFace == RenderFrontFace::COUNTER_CLOCKWISE;
+
         psoDesc.DepthStencilState.DepthEnable = desc.depthEnabled;
         psoDesc.DepthStencilState.DepthWriteMask = desc.depthWriteEnabled ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
         psoDesc.DepthStencilState.DepthFunc = toD3D12(desc.depthFunction);

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -603,6 +603,18 @@ namespace plume {
         }
     }
 
+    MTL::Winding mapFrontFace(RenderFrontFace frontFace) {
+        switch (frontFace) {
+            case RenderFrontFace::CLOCKWISE:
+                return MTL::WindingClockwise;
+            case RenderFrontFace::COUNTER_CLOCKWISE:
+                return MTL::WindingCounterClockwise;
+            default:
+                assert(false && "Unknown front face.");
+                return MTL::WindingClockwise;
+        }
+    }
+
     MTL::PrimitiveTopologyClass mapPrimitiveTopologyClass(RenderPrimitiveTopology topology) {
         switch (topology) {
             case RenderPrimitiveTopology::POINT_LIST:
@@ -1558,7 +1570,7 @@ namespace plume {
         state.depthStencilState = device->mtl->newDepthStencilState(depthStencilDescriptor);
         state.cullMode = mapCullMode(desc.cullMode);
         state.depthClipMode = (desc.depthClipEnabled) ? MTL::DepthClipModeClip : MTL::DepthClipModeClamp;
-        state.winding = MTL::WindingClockwise;
+        state.winding = mapFrontFace(desc.frontFace);
         state.renderPipelineState = device->mtl->newRenderPipelineState(descriptor, &error);
         state.primitiveType = mapPrimitiveType(desc.primitiveTopology);
         state.stencilReference = desc.stencilEnabled ? desc.stencilReference : 0;

--- a/plume_render_interface_types.h
+++ b/plume_render_interface_types.h
@@ -202,6 +202,12 @@ namespace plume {
         BACK
     };
 
+    enum class RenderFrontFace {
+        UNKNOWN,
+        CLOCKWISE,
+        COUNTER_CLOCKWISE
+    };
+
     enum class RenderComparisonFunction {
         UNKNOWN,
         NEVER,
@@ -1266,6 +1272,7 @@ namespace plume {
         bool alphaToCoverageEnabled = false;
         RenderPrimitiveTopology primitiveTopology = RenderPrimitiveTopology::TRIANGLE_LIST;
         RenderCullMode cullMode = RenderCullMode::NONE;
+        RenderFrontFace frontFace = RenderFrontFace::CLOCKWISE;
         RenderFormat renderTargetFormat[MaxRenderTargets] = {};
         RenderBlendDesc renderTargetBlend[MaxRenderTargets] = {};
         uint32_t renderTargetCount = 0;

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -321,6 +321,18 @@ namespace plume {
         }
     }
 
+    static VkFrontFace toVk(RenderFrontFace frontFace) {
+        switch (frontFace) {
+        case RenderFrontFace::CLOCKWISE:
+            return VK_FRONT_FACE_CLOCKWISE;
+        case RenderFrontFace::COUNTER_CLOCKWISE:
+            return VK_FRONT_FACE_COUNTER_CLOCKWISE;
+        default:
+            assert(false && "Unknown front face.");
+            return VK_FRONT_FACE_CLOCKWISE;
+        }
+    }
+
     static VkPrimitiveTopology toVk(RenderPrimitiveTopology topology) {
         switch (topology) {
         case RenderPrimitiveTopology::POINT_LIST:
@@ -1499,7 +1511,7 @@ namespace plume {
         rasterization.polygonMode = VK_POLYGON_MODE_FILL;
         rasterization.lineWidth = 1.0f;
         rasterization.cullMode = toVk(desc.cullMode);
-        rasterization.frontFace = VK_FRONT_FACE_CLOCKWISE;
+        rasterization.frontFace = toVk(desc.frontFace);
 
         if (desc.dynamicDepthBiasEnabled) {
             rasterization.depthBiasEnable = true;


### PR DESCRIPTION
Needed for MarathonRecomp; it seems that D3DCULL was extended on Xbox 360 to allow specifying the front face winding order.