### PR TITLE
fix: fallback to UPLOAD heapType for devices without GPU_UPLOAD support

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -465,7 +465,7 @@ namespace plume {
         }
     }
 
-    static D3D12_HEAP_TYPE toD3D12(RenderHeapType type) {
+    static D3D12_HEAP_TYPE toD3D12(RenderHeapType type, bool gpuUploadHeapFallback) {
         switch (type) {
         case RenderHeapType::DEFAULT:
             return D3D12_HEAP_TYPE_DEFAULT;
@@ -474,6 +474,9 @@ namespace plume {
         case RenderHeapType::READBACK:
             return D3D12_HEAP_TYPE_READBACK;
         case RenderHeapType::GPU_UPLOAD:
+            if (gpuUploadHeapFallback) {
+                return D3D12_HEAP_TYPE_UPLOAD;
+            }
             return D3D12_HEAP_TYPE_GPU_UPLOAD;
         default:
             assert(false && "Unknown heap type.");
@@ -2757,7 +2760,7 @@ namespace plume {
 
         D3D12MA::ALLOCATION_DESC allocationDesc = {};
         allocationDesc.Flags = desc.committed ? D3D12MA::ALLOCATION_FLAG_COMMITTED : D3D12MA::ALLOCATION_FLAG_NONE;
-        allocationDesc.HeapType = toD3D12(desc.heapType);
+        allocationDesc.HeapType = toD3D12(desc.heapType, device->gpuUploadHeapFallback);
         allocationDesc.CustomPool = (pool != nullptr) ? pool->d3d : nullptr;
 
         HRESULT res = device->allocator->CreateResource(&allocationDesc, &resourceDesc, resourceStates, nullptr, &allocation, IID_PPV_ARGS(&d3d));
@@ -2931,7 +2934,7 @@ namespace plume {
             poolDesc.HeapProperties = device->d3d->GetCustomHeapProperties(0, D3D12_HEAP_TYPE_UPLOAD);
         }
         else {
-            poolDesc.HeapProperties.Type = toD3D12(desc.heapType);
+            poolDesc.HeapProperties.Type = toD3D12(desc.heapType, gpuUploadHeapFallback);
         }
 
         poolDesc.MinBlockCount = desc.minBlockCount;

--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -474,10 +474,7 @@ namespace plume {
         case RenderHeapType::READBACK:
             return D3D12_HEAP_TYPE_READBACK;
         case RenderHeapType::GPU_UPLOAD:
-            if (gpuUploadHeapFallback) {
-                return D3D12_HEAP_TYPE_UPLOAD;
-            }
-            return D3D12_HEAP_TYPE_GPU_UPLOAD;
+            return gpuUploadHeapFallback ? D3D12_HEAP_TYPE_UPLOAD : D3D12_HEAP_TYPE_GPU_UPLOAD;
         default:
             assert(false && "Unknown heap type.");
             return D3D12_HEAP_TYPE_DEFAULT;


### PR DESCRIPTION
I was running into this issue for a project when running D3D12 on an Intel iGPU (13th gen i9, UHD Graphics, Driver 32.0.101.7084 - on Win 11 23H2 ENT/BUS), where upon parsing a vertex declaration I would get
`CreateResource failed with error code 0x80004001.`, specifically breaking on
```c++
    static void setObjectName(ID3D12Object *object, const std::string &name) {
        const std::wstring wideCharName = Utf8ToUtf16(name);
        object->SetName(wideCharName.c_str());
    }
```
Line 773 of plume_d3d12.cpp

With the proposed change I am able to use D3D12 for both my Nvidia dGPU and Intel iGPU