### PR TITLE
Fix Metal crash on Intel Mac AMD GPU (missing setArgumentBuffer)

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1847,6 +1847,12 @@ namespace plume {
                         uint64_t gpuAddress = nativeBuffer->gpuAddress() + bufferDescriptor->offset;
                         *reinterpret_cast<uint64_t*>(bufferPtr + argumentOffset) = gpuAddress;
                     } else {
+                        // On Tier 2 devices without direct buffer addresses (e.g. Intel Mac AMD on macOS 11+),
+                        // the argument encoder's backing buffer must be set before encoding arguments.
+                        // macOS 11+ reports all GPUs as Tier 2, but Intel AMD GPUs skip setArgumentBuffer
+                        // in the constructor because useArgumentBuffersTier2 is true. Without this call
+                        // the encoder has no backing buffer, causing a SIGSEGV in AMDMTLBronzeDriver.
+                        argumentBuffer.argumentEncoder->setArgumentBuffer(argumentBuffer.mtl, argumentBuffer.offset);
                         argumentBuffer.argumentEncoder->setBuffer(nativeBuffer, bufferDescriptor->offset, argumentIndex);
                     }
                     nativeBuffer->retain();


### PR DESCRIPTION
## Problem

On macOS 11+, all GPUs are reported as Metal Argument Buffers Tier 2.
The `MetalDescriptorSet` constructor therefore skips calling
`setArgumentBuffer()` on the argument encoder when
`useArgumentBuffersTier2 = true`. However, when `setDescriptor()` later
calls `argumentEncoder->setBuffer(...)` for a `DataTypePointer` binding,
the AMD driver crashes because the encoder has no backing buffer:

```
-[BronzeMtlIndirectArgumentBufferEncoder setBuffer:offset:atIndex:] + 44
plume::MetalDescriptorSet::setDescriptor(...)
```

Crash observed on: Intel MacBook Pro, AMD Radeon 555X (AMDMTLBronzeDriver),
macOS 15.7.4.

## Fix

In the `DataTypePointer` case of `setDescriptor`, call `setArgumentBuffer()`
before `setBuffer()` when `useDirectBufferAddresses` is false (i.e. not on
Metal3 hardware). This gives the encoder a valid backing buffer before any
encode operations:

```cpp
argumentBuffer.argumentEncoder->setArgumentBuffer(argumentBuffer.mtl,
                                                  argumentBuffer.offset);
argumentBuffer.argumentEncoder->setBuffer(nativeBuffer,
                                          bufferDescriptor->offset,
                                          argumentIndex);
```

## Impact

- **Intel Mac AMD (`useArgumentBuffersTier2 = true`, `useDirectBufferAddresses = false`)**: crash eliminated.
- **Apple Silicon / Metal3 (`useDirectBufferAddresses = true`)**: takes the direct GPU-address path as before — no change.
- **Tier1 devices (`useArgumentBuffersTier2 = false`)**: `setArgumentBuffer` is already called in the constructor; this path is unchanged.