### PR TITLE
Fix Metal command buffer ownership in command lists

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -3554,6 +3554,7 @@ namespace plume {
         if (activeBlitEncoder == nullptr) {
             activeBlitEncoder = mtl->blitCommandEncoder(device->sharedBlitDescriptor);
             activeBlitEncoder->setLabel(MTLSTR("Copy Blit Encoder"));
+            activeBlitEncoder->retain();
 
             startedEncoding = true;
 

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -2238,7 +2238,9 @@ namespace plume {
     }
 
     MetalCommandList::~MetalCommandList() {
-        mtl->release();
+        if (mtl != nullptr) {
+            mtl->release();
+        }
 
         for (auto& fenceSet : fences) {
             for (auto* fence : fenceSet) {
@@ -2253,6 +2255,7 @@ namespace plume {
         assert(mtl == nullptr);
         startedEncoding = false;
         mtl = queue->mtl->commandBufferWithUnretainedReferences();
+        mtl->retain();
         mtl->setLabel(MTLSTR("RT64 Command List"));
 
         // Reset fence waits and updates for new command list.

--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -1196,8 +1196,6 @@ namespace plume {
         // Create texture with configured descriptor and alignment
         MTL::TextureDescriptor *descriptor = MTL::TextureDescriptor::textureBufferDescriptor(pixelFormat, width, options, usage);
         this->texture = buffer->mtl->newTexture(descriptor, 0, bytesPerRow);
-
-        descriptor->release();
     }
 
     MetalBufferFormattedView::~MetalBufferFormattedView() {


### PR DESCRIPTION
'Clean' closures of recompiled apps (e.g. Zelda64Recomp, MarioKart64 and most importantly Snowboard Kids 2 :P) are being reported as crashes.

If we dig into what is going on here:

```
NSZombieEnabled=YES NSDeallocateZombies=NO OBJC_PRINT_EXCEPTIONS=YES ./build/SnowboardKids2Recompiled.app/Contents/MacOS/SnowboardKids2Recompiled
```

We see:

```
-[AGXG14GFamilyCommandBuffer release]: message sent to deallocated instance
```

Looking through usage of mtl, we see that MetalCommandList saves a pointer to the command buffer without retaining a reference to it. My layman's reading of the Metal docs suggest that we do need to call retain since in this case we're saving a reference to a pointer we do not own.