### PR TITLE
Metal: Disable hazard tracking always.

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -836,16 +836,17 @@ namespace plume {
     }
 
     MTL::ResourceOptions mapResourceOption(RenderHeapType heapType) {
+        const MTL::ResourceOptions commonOptions = MTL::ResourceHazardTrackingModeUntracked | MTL::ResourceCPUCacheModeDefaultCache;
         switch (heapType) {
             case RenderHeapType::DEFAULT:
-                return MTL::ResourceStorageModePrivate;
+                return commonOptions | MTL::ResourceStorageModePrivate;
             case RenderHeapType::UPLOAD:
             case RenderHeapType::READBACK:
             case RenderHeapType::GPU_UPLOAD:
-                return MTL::ResourceStorageModeShared;
+                return commonOptions | MTL::ResourceStorageModeShared;
             default:
                 assert(false && "Unknown heap type.");
-                return MTL::ResourceStorageModePrivate;
+                return commonOptions | MTL::ResourceStorageModePrivate;
         }
     }
 


### PR DESCRIPTION
Plume expects the user to manage hazards with barriers, and Metal's automatic hazard tracking is already implicitly disabled when using residency sets. Disable it always for consistent behavior and potentially improved performance.

Applied a CPU cache mode as well just to be explicit with all of the resource options, it's the same as the usual default.