### PR TITLE
fix(d3d12): close waitable swap chain handle

### DIFF
--- a/plume_d3d12.cpp
+++ b/plume_d3d12.cpp
@@ -1383,6 +1383,11 @@ namespace plume {
             }
         }
 
+        if (waitableObject != NULL) {
+            CloseHandle(waitableObject);
+            waitableObject = NULL;
+        }
+
         if (d3d != nullptr) {
             d3d->Release();
         }


### PR DESCRIPTION
Closes https://github.com/rt64/rt64/issues/165

The D3D12 swap chain stores the handle returned by `GetFrameLatencyWaitableObject()`, but the handle was not closed when the swap chain was destroyed.

Close `waitableObject` in `D3D12SwapChain::~D3D12SwapChain()` before releasing the swap chain.

Tested by:
- Building `plume` with MSVC/CLion on Windows.
- Running `plume_triangle`.
- Confirming the destructor reaches `CloseHandle(waitableObject)` with a valid handle (`0x6d0`).
- Confirming the handle is reset to `NULL` and the example exits normally.