### PR TITLE
Ensure nullBuffer is reset before resourcesMutex is destroyed

### DIFF
--- a/plume_metal.cpp
+++ b/plume_metal.cpp
@@ -3870,6 +3870,8 @@ namespace plume {
         clearDepthFunction->release();
         sharedBlitDescriptor->release();
 
+        nullBuffer.reset();
+
         if (residencySet != nullptr) {
             residencySet->endResidency();
             residencySet->release();


### PR DESCRIPTION
Pulling in the latest Plume changes addresses the original issues during process termination but we now see a new error (at least on the Snowboard Kids 2 Recomp) when closing the game:

```
libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
```

This appears to be due to the destruction order of these entities in C++. Specifically nullBuffer needs to be reset before the resourcesMutex is destroyed. This does not appear to be an issue prior to 4f556be1531698174a597e7e0a215c22d3238a24 but I'm not sure why.