### PR TITLE
vulkan scaled vertex formats

### DIFF
--- a/plume_render_interface_types.h
+++ b/plume_render_interface_types.h
@@ -160,6 +160,9 @@ namespace plume {
         BC7_TYPELESS,
         BC7_UNORM,
         BC7_UNORM_SRGB,
+        R8G8B8A8_USCALED,
+        R16G16_SSCALED,
+        R16G16B16A16_SSCALED,
         MAX
     };
 

--- a/plume_vulkan.cpp
+++ b/plume_vulkan.cpp
@@ -133,6 +133,8 @@ namespace plume {
             return VK_FORMAT_R16G16B16A16_SNORM;
         case RenderFormat::R16G16B16A16_SINT:
             return VK_FORMAT_R16G16B16A16_SINT;
+        case RenderFormat::R16G16B16A16_SSCALED:
+            return VK_FORMAT_R16G16B16A16_SSCALED;
         case RenderFormat::R32G32_TYPELESS:
             return VK_FORMAT_R32G32_SFLOAT;
         case RenderFormat::R32G32_FLOAT:
@@ -143,6 +145,8 @@ namespace plume {
             return VK_FORMAT_R8G8B8A8_UNORM;
         case RenderFormat::R8G8B8A8_UINT:
             return VK_FORMAT_R8G8B8A8_UINT;
+        case RenderFormat::R8G8B8A8_USCALED:
+            return VK_FORMAT_R8G8B8A8_USCALED;
         case RenderFormat::R8G8B8A8_SNORM:
             return VK_FORMAT_R8G8B8A8_SNORM;
         case RenderFormat::R8G8B8A8_SINT:
@@ -157,6 +161,8 @@ namespace plume {
             return VK_FORMAT_R16G16_UNORM;
         case RenderFormat::R16G16_UINT:
             return VK_FORMAT_R16G16_UINT;
+        case RenderFormat::R16G16_SSCALED:
+            return VK_FORMAT_R16G16_SSCALED;
         case RenderFormat::R16G16_SNORM:
             return VK_FORMAT_R16G16_SNORM;
         case RenderFormat::R16G16_SINT:


### PR DESCRIPTION
This PR adds RenderFormat entries and Vulkan mappings for R8G8B8A8_USCALED, R16G16_SSCALED, and R16G16B16A16_SSCALED. re:Blue needs these formats when running through MVK so the vertex data can reach floating-point shader inputs without causing mismatches during pipeline creation.

  - R8G8B8A8_USCALED: Unsigned quads become unnormalized floating-point attributes.
  - R16G16_SSCALED: Signed pairs become unnormalized floating-point attributes.
  - R16G16B16A16_SSCALED: Signed quads become unnormalized floating-point attributes.
